### PR TITLE
psi4 procrouting update

### DIFF
--- a/pymodule.py
+++ b/pymodule.py
@@ -25,7 +25,7 @@
 import psi4
 from psi4 import core
 import psi4.driver.p4util as p4util
-from psi4.driver.procedures import proc_util
+from psi4.driver.procrouting import proc_util
 
 
 def run_v2rdm_casscf(name, **kwargs):

--- a/threeindexintegrals.cc
+++ b/threeindexintegrals.cc
@@ -227,7 +227,7 @@ void v2RDMSolver::ThreeIndexIntegrals() {
     psio->close(PSIF_DCC_QMO,1);
     psio->close(PSIF_DCC_QSO,1);
 
-    delete rowdims;
+    delete[] rowdims;
 
     //F_DGEMM('t','t',nso_*nQ_,nso_,nso_,1.0,tmp1,nso_,&(myCa->pointer()[0][0]),nso_,0.0,tmp2,nso_*nQ_);
     //F_DGEMM('t','t',nso_*nQ_,nso_,nso_,1.0,tmp2,nso_,&(myCa->pointer()[0][0]),nso_,0.0,tmp1,nso_*nQ_);
@@ -280,7 +280,7 @@ void v2RDMSolver::ThreeIndexIntegrals() {
     }
     psio->close(PSIF_DCC_QMO,1);
 
-    delete rowdims2;
+    delete[] rowdims2;
     free(tmp3);
 
 }

--- a/v2rdm_solver.cc
+++ b/v2rdm_solver.cc
@@ -204,6 +204,7 @@ void  v2RDMSolver::common_init(){
     escf_     = reference_wavefunction_->reference_energy();
     nalpha_   = reference_wavefunction_->nalpha();
     nbeta_    = reference_wavefunction_->nbeta();
+    nirrep_   = reference_wavefunction_->nirrep();
     nalphapi_ = reference_wavefunction_->nalphapi();
     nbetapi_  = reference_wavefunction_->nbetapi();
     doccpi_   = reference_wavefunction_->doccpi();
@@ -211,7 +212,6 @@ void  v2RDMSolver::common_init(){
     frzcpi_   = reference_wavefunction_->frzcpi();
     frzvpi_   = reference_wavefunction_->frzvpi();
     nmopi_    = reference_wavefunction_->nmopi();
-    nirrep_   = reference_wavefunction_->nirrep();
     nso_      = reference_wavefunction_->nso();
     nmo_      = reference_wavefunction_->nmo();
     nsopi_    = reference_wavefunction_->nsopi();


### PR DESCRIPTION
* There was a dictionary "procedures" and a driver dictionary "procedures". A conflict someday was inevitable so we renamed one. Unfortunately, plugins use both by name, so they couldn't be protected from the change.
* I got a couple delete warnings, so fixed them as it advised. Check that it's sensible.
* I was having an awful time with a segfault on Mac, so I tried updating to the new Dimension usage. That turned out not to be the problem, so it's not in this PR, but [here's the diff](https://github.com/loriab/v2rdm_casscf/commit/a8413f43068814b1bd071936e143306ac7964b08) if you're curious about its usage.
* Please to mint a new tag after this is in. `v0.2.1` would do fine.