### PR TITLE
Updates psi4 headers and removes ULI after psi4/psi4#736

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
 project(v2rdm_casscf
-        VERSION 0.1
+        VERSION 0.3
         LANGUAGES CXX Fortran)
 set(v2rdm_casscf_AUTHORS      "A. Eugene DePrince III")
 set(v2rdm_casscf_DESCRIPTION  "Variational 2-RDM-driven CASSCF plugin to Psi4")

--- a/basis.cc
+++ b/basis.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 

--- a/cg_solver.cc
+++ b/cg_solver.cc
@@ -31,7 +31,6 @@
 
 #include <psi4/libplugin/plugin.h>
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libpsio/psio.hpp>
 #include <psi4/libqt/qt.h>

--- a/checkpoint.cc
+++ b/checkpoint.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 

--- a/d2.cc
+++ b/d2.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 

--- a/d3.cc
+++ b/d3.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/d4.cc
+++ b/d4.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/g2.cc
+++ b/g2.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/oei.cc
+++ b/oei.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/q2.cc
+++ b/q2.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/sortintegrals.cc
+++ b/sortintegrals.cc
@@ -27,6 +27,7 @@
 
 #include <psi4/psi4-dec.h>
 #include <psi4/psifiles.h>
+#include <psi4/libpsi4util/PsiOutStream.h>
 #include <psi4/libiwl/iwl.h>
 #include <psi4/libpsio/psio.hpp>
 #include <psi4/libtrans/integraltransform.h>
@@ -41,11 +42,11 @@ namespace psi{namespace v2rdm_casscf{
 
 void ReadAllIntegrals(iwlbuf *Buf,double*tei,long int nmo) {
 
-  ULI lastbuf;
+  size_t lastbuf;
   Label *lblptr;
   Value *valptr;
 
-  ULI idx, p, q, r, s, pq, rs, pqrs;
+  size_t idx, p, q, r, s, pq, rs, pqrs;
 
   lblptr = Buf->labels;
   valptr = Buf->values;
@@ -57,10 +58,10 @@ void ReadAllIntegrals(iwlbuf *Buf,double*tei,long int nmo) {
     * first buffer (read in when Buf was initialized)
     */
   for (idx=4*Buf->idx; Buf->idx<Buf->inbuf; Buf->idx++) {
-      p = (ULI) lblptr[idx++];
-      q = (ULI) lblptr[idx++];
-      r = (ULI) lblptr[idx++];
-      s = (ULI) lblptr[idx++];
+      p = (size_t) lblptr[idx++];
+      q = (size_t) lblptr[idx++];
+      r = (size_t) lblptr[idx++];
+      s = (size_t) lblptr[idx++];
 
       pq   = INDEX(p,q);
       rs   = INDEX(r,s);
@@ -86,10 +87,10 @@ void ReadAllIntegrals(iwlbuf *Buf,double*tei,long int nmo) {
       lastbuf = Buf->lastbuf;
       for (idx=4*Buf->idx; Buf->idx<Buf->inbuf; Buf->idx++) {
 
-          p = (ULI) lblptr[idx++];
-          q = (ULI) lblptr[idx++];
-          r = (ULI) lblptr[idx++];
-          s = (ULI) lblptr[idx++];
+          p = (size_t) lblptr[idx++];
+          q = (size_t) lblptr[idx++];
+          r = (size_t) lblptr[idx++];
+          s = (size_t) lblptr[idx++];
 
           pq   = INDEX(p,q);
           rs   = INDEX(r,s);

--- a/t1.cc
+++ b/t1.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/t2.cc
+++ b/t2.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/tei.cc
+++ b/tei.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/threeindexintegrals.cc
+++ b/threeindexintegrals.cc
@@ -25,7 +25,8 @@
  *
  */
 
-#include"v2rdm_solver.h"
+#include "v2rdm_solver.h"
+#include <psi4/libpsi4util/process.h>
 #include <psi4/libpsio/psio.hpp>
 #include <psi4/libmints/basisset.h>
 #include <psi4/libmints/sieve.h>

--- a/update_primal.cc
+++ b/update_primal.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/update_transformation_matrix.cc
+++ b/update_transformation_matrix.cc
@@ -26,7 +26,6 @@
  */
 
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libtrans/integraltransform.h>

--- a/v2rdm_casscf.cc
+++ b/v2rdm_casscf.cc
@@ -29,6 +29,7 @@
 
 #include <psi4/psi4-dec.h>
 #include <psi4/libciomr/libciomr.h>
+#include <psi4/libpsi4util/process.h>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/v2rdm_solver.cc
+++ b/v2rdm_solver.cc
@@ -29,6 +29,7 @@
 #include<stdlib.h>
 #include<math.h>
 
+#include <psi4/libmints/molecule.h>
 #include <psi4/libmints/basisset.h>
 #include <psi4/libmints/factory.h>
 #include <psi4/libmints/writer.h>
@@ -37,7 +38,7 @@
 #include <psi4/libtrans/mospace.h>
 #include <psi4/libplugin/plugin.h>
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
+#include <psi4/libpsi4util/process.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libqt/qt.h>
 #include <psi4/libpsio/psio.hpp>

--- a/v2rdm_solver.h
+++ b/v2rdm_solver.h
@@ -34,7 +34,6 @@
 
 #include <psi4/libplugin/plugin.h>
 #include <psi4/psi4-dec.h>
-#include <psi4/libparallel/parallel.h>
 #include <psi4/liboptions/liboptions.h>
 #include <psi4/libpsio/psio.hpp>
 #include <psi4/libqt/qt.h>


### PR DESCRIPTION
After a header rearrange in psi4/psi4#736, this plugin doesn't compile anymore. You'll probably want to store this version on a non-master branch _or_ copy current master to a `psi4-1.1` branch and accept this into master. That way ppl can use v2rdm with psi4 1.1 _or_ current devel head.