### PR TITLE
testing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ script:
   - cd ..
   - python -c "import v2rdm_casscf; print(v2rdm_casscf.__version__)"
   # v2 source: full test & codecov
-  - python -c "import v2rdm_casscf as v2; v2.test(extras=['--cov', '--durations=5'])"
+  - python -c "import v2rdm_casscf as v2; rc = v2.test(extras=['--cov', '--durations=5']); import sys; sys.exit(rc)"
   # v2 install: quick test
   - cd v2rdm_casscf && make install && cd .. && rm -rf v2rdm_casscf
-  - python -c "import v2rdm_casscf as v2; v2.test('quick')"
+  - python -c "import v2rdm_casscf as v2; rc = v2.test('quick'); import sys; sys.exit(rc)"
 
 notifications:
   email: false

--- a/extras.py
+++ b/extras.py
@@ -15,6 +15,11 @@ def test(extent='full', extras=None):
     extras : list
         Additional arguments to pass to `pytest`.
 
+    Returns
+    -------
+    int
+        Return code from `pytest.main()`. 0 for pass, 1 for fail.
+
     """
     try:
         import pytest
@@ -33,4 +38,5 @@ def test(extent='full', extras=None):
         command.extend(extras)
     command.extend(['--capture=sys', abs_test_dir])
 
-    pytest.main(command)
+    retcode = pytest.main(command)
+    return retcode

--- a/tests/v2rdm6/input.dat
+++ b/tests/v2rdm6/input.dat
@@ -39,6 +39,6 @@ refscf   = -108.95016246035139    # TEST
 refv2rdm = -109.095505119442     # TEST
 
 compare_values(refnuc,   n2.nuclear_repulsion_energy(),  4, "Nuclear repulsion energy")  #TEST
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 6, "SCF total energy")          # TEST
+compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 5, "SCF total energy")          # TEST
 compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy") # TEST
 


### PR DESCRIPTION
Impressive. You had a test that needed its tol tweaking (I had already adjusted the psiapi version). But that wasn't triggering build failure, so raising the return code was another issue. And in later commits its failing b/c I haven't moved the `psi4PluginCache.cmake` file from psi4 to psi4-dev pkgs.

This PR hits the first two.