### PR TITLE
Added the capability of rotating inital guess orbitals for v2rdm-CASS…

### DIFF
--- a/pymodule.py
+++ b/pymodule.py
@@ -26,6 +26,7 @@ import re
 import os
 import math
 import warnings
+import numpy
 
 import psi4
 from psi4.driver.procrouting import proc_util
@@ -61,6 +62,48 @@ def run_v2rdm_casscf(name, **kwargs):
     scf_type = psi4.core.get_option('SCF', 'SCF_TYPE')
     if ( scf_type == 'PK' or scf_type == 'DIRECT' ):
         proc_util.check_iwl_file_from_scf_type(psi4.core.get_option('SCF', 'SCF_TYPE'), ref_wfn)
+
+    # reorder wavefuntions based on user input
+    # apply a list of 2x2 rotation matrices to the orbitals in the form of [irrep, orbital1, orbital2, theta]
+    # where an angle of 0 would do nothing and an angle of 90 would switch the two orbitals.
+    # the indices of irreps and orbitals start from 0
+    reorder_orbitals = psi4.core.get_option("V2RDM_CASSCF","MCSCF_ROTATE")
+    for orbord in reorder_orbitals:
+        if type(orbord) != list :
+            raise psi4.p4util.PsiException("Each element of the orbtial rotate list requires 4 arguements (irrep, orb1, orb2, theta).")
+        if len(orbord) != 4:
+            raise psi4.p4util.PsiException("Each element of the orbtial rotate list requires 4 arguements (irrep, orb1, orb2, theta).")
+
+        irrep, orb1, orb2, theta = orbord
+
+        if irrep > ref_wfn.Ca().nirrep():
+            raise psi4.p4util.PsiException("REORDER_ORBITALS: Expression %s irrep number is larger than the number of irreps" %
+                                    (str(orbord)))
+
+        if max(orb1, orb2) > ref_wfn.Ca().coldim()[irrep]:
+            raise psi4.p4util.PsiException("REORDER_ORBITALS: Expression %s orbital number exceeds number of orbitals in irrep" %
+                                    (str(orbord)))
+
+        theta = numpy.deg2rad(theta)
+
+        x_a = ref_wfn.Ca().nph[irrep][:, orb1].copy()
+        y_a = ref_wfn.Ca().nph[irrep][:, orb2].copy()
+
+        xp_a = numpy.cos(theta) * x_a - numpy.sin(theta) * y_a
+        yp_a = numpy.sin(theta) * x_a + numpy.cos(theta) * y_a
+
+        ref_wfn.Ca().nph[irrep][:, orb1] = xp_a
+        ref_wfn.Ca().nph[irrep][:, orb2] = yp_a
+
+        x_b = ref_wfn.Ca().nph[irrep][:, orb1].copy()
+        y_b = ref_wfn.Ca().nph[irrep][:, orb2].copy()
+
+        xp_b = numpy.cos(theta) * x_b - numpy.sin(theta) * y_b
+        yp_b = numpy.sin(theta) * x_b + numpy.cos(theta) * y_b
+
+        ref_wfn.Ca().nph[irrep][:, orb1] = xp_b
+        ref_wfn.Ca().nph[irrep][:, orb2] = yp_b
+
 
     returnvalue = psi4.core.plugin('v2rdm_casscf.so', ref_wfn)
 

--- a/tests/mcscf_rotate_test/input.dat
+++ b/tests/mcscf_rotate_test/input.dat
@@ -1,0 +1,108 @@
+#! STO-3g benzene (6,6) guess orbital rotation test DQG
+
+# job description:
+print('        benzene (6,6), scf_type = PK')
+
+sys.path.insert(0, '../../..')
+import v2rdm_casscf
+
+# orbital rotation needed before MCSCF calculation
+molecule benzene_c1 {
+0 1
+symmetry c1
+ C                  0.00000000    1.38980400    0.00000000
+ C                  1.20360500    0.69490200    0.00000000
+ C                  1.20360500   -0.69490200    0.00000000
+ C                  0.00000000   -1.38980400    0.00000000
+ C                 -1.20360500   -0.69490200    0.00000000
+ C                 -1.20360500    0.69490200    0.00000000
+ H                  0.00000000    2.47523400    0.00000000
+ H                  2.14361600    1.23761700    0.00000000
+ H                  2.14361600   -1.23761700    0.00000000
+ H                  0.00000000   -2.47523400    0.00000000
+ H                 -2.14361600   -1.23761700    0.00000000
+ H                 -2.14361600    1.23761700    0.00000000
+}
+
+set {
+  basis sto-3g
+  scf_type pk
+  d_convergence      1e-10
+  maxiter 500
+  restricted_docc [ 18 ]
+  active          [ 6  ]
+}
+
+energy ('hf')
+
+set v2rdm_casscf {
+# Switch the 17th (index 16) and the 19th (index 18) orbitals of the 1st irrep (index 0)
+# If more than one set of orbitals need to be rotated, use the following syntex
+# mcscf_rotate [[irrep_1, orb1_1, orb2_1, theta_1], [irrep_2, orb1_2, orb2_2, theta2],...]
+# Setting theta to 90 would switch the orbitals, setting it to 0 does nothing.
+  mcscf_rotate [[ 0, 16, 18, 90 ]]
+  positivity dq
+  r_convergence  1e-5
+  e_convergence  1e-6
+  maxiter 20000
+  guess_orbitals_write false
+  molden_write false
+}
+
+activate(benzene_c1)
+
+E_c1=energy('v2rdm-casscf')
+
+
+clean()
+
+# reference calculation, no need to rotate orbitals for MCSCF
+molecule benzene_d2h {
+0 1
+symmetry d2h
+ C                  0.00000000    1.38980400    0.00000000
+ C                  1.20360500    0.69490200    0.00000000
+ C                  1.20360500   -0.69490200    0.00000000
+ C                  0.00000000   -1.38980400    0.00000000
+ C                 -1.20360500   -0.69490200    0.00000000
+ C                 -1.20360500    0.69490200    0.00000000
+ H                  0.00000000    2.47523400    0.00000000
+ H                  2.14361600    1.23761700    0.00000000
+ H                  2.14361600   -1.23761700    0.00000000
+ H                  0.00000000   -2.47523400    0.00000000
+ H                 -2.14361600   -1.23761700    0.00000000
+ H                 -2.14361600    1.23761700    0.00000000
+}
+
+set {
+  basis sto-3g
+  scf_type pk
+  d_convergence      1e-10
+  maxiter 500
+  restricted_docc [ 6, 3, 0, 0, 0, 0, 5, 4 ]
+  active          [ 0, 0, 1, 2, 1, 2, 0, 0 ]
+}
+
+energy('hf')
+
+set v2rdm_casscf {
+# Note that when mcscf_rotate is set for the previous molecule, the calculations afterwards
+#   also use this input, unless you overwrite it. A safe way to unset it is to overwrite it
+#   with mcscf_rotate [[0, 0, 0, 0]], which should work as long as your molecule has at 
+#   least 1 orbital in the 1st irrep. This problem can also be simply avoided by calculating 
+#   the molecules that do not require orbital rotations first.
+  mcscf_rotate [[ 0, 0, 0, 0 ]]
+  positivity dq
+  r_convergence  1e-5
+  e_convergence  1e-6
+  maxiter 20000
+  guess_orbitals_write false
+  molden_write false
+}
+
+activate(benzene_d2h)
+
+E_d2h=energy('v2rdm-casscf')
+
+compare_values(E_c1, E_d2h, 4, "v2RDM-CASSCF total energy") # TEST
+

--- a/tests/mcscf_rotate_test/output.ref
+++ b/tests/mcscf_rotate_test/output.ref
@@ -1,0 +1,5387 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.2rc3.dev1 
+
+                         Git: Rev {master} b0f5b75 dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Thursday, 14 June 2018 05:08PM
+
+    Process ID: 6754
+    Host:       ed10
+    PSIDATADIR: /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! STO-3g benzene (6,6) guess orbital rotation test DQG
+
+# job description:
+print('        benzene (6,6), scf_type = PK')
+
+sys.path.insert(0, '../../..')
+import v2rdm_casscf
+
+# orbital rotation needed before MCSCF calculation
+molecule benzene_c1 {
+0 1
+symmetry c1
+ C                  0.00000000    1.38980400    0.00000000
+ C                  1.20360500    0.69490200    0.00000000
+ C                  1.20360500   -0.69490200    0.00000000
+ C                  0.00000000   -1.38980400    0.00000000
+ C                 -1.20360500   -0.69490200    0.00000000
+ C                 -1.20360500    0.69490200    0.00000000
+ H                  0.00000000    2.47523400    0.00000000
+ H                  2.14361600    1.23761700    0.00000000
+ H                  2.14361600   -1.23761700    0.00000000
+ H                  0.00000000   -2.47523400    0.00000000
+ H                 -2.14361600   -1.23761700    0.00000000
+ H                 -2.14361600    1.23761700    0.00000000
+}
+
+set {
+  basis sto-3g
+  scf_type pk
+  d_convergence      1e-10
+  maxiter 500
+  restricted_docc [ 18 ]
+  active          [ 6  ]
+}
+
+energy ('hf')
+
+set v2rdm_casscf {
+# Switch the 17th (index 16) and the 19th (index 18) orbitals of the 1st irrep (index 0)
+# If more than one set of orbitals need to be rotated, use the following syntex
+# mcscf_rotate [[irrep_1, orb1_1, orb2_1, theta_1], [irrep_2, orb1_2, orb2_2, theta2],...]
+# Setting theta to 90 would switch the orbitals, setting it to 0 does nothing.
+  mcscf_rotate [[ 0, 16, 18, 90 ]]
+  positivity dq
+  r_convergence  1e-5
+  e_convergence  1e-6
+  maxiter 20000
+  guess_orbitals_write false
+  molden_write false
+}
+
+activate(benzene_c1)
+
+E_c1=energy('v2rdm-casscf')
+
+
+clean()
+
+# reference calculation, no need to rotate orbitals for MCSCF
+molecule benzene_d2h {
+0 1
+symmetry d2h
+ C                  0.00000000    1.38980400    0.00000000
+ C                  1.20360500    0.69490200    0.00000000
+ C                  1.20360500   -0.69490200    0.00000000
+ C                  0.00000000   -1.38980400    0.00000000
+ C                 -1.20360500   -0.69490200    0.00000000
+ C                 -1.20360500    0.69490200    0.00000000
+ H                  0.00000000    2.47523400    0.00000000
+ H                  2.14361600    1.23761700    0.00000000
+ H                  2.14361600   -1.23761700    0.00000000
+ H                  0.00000000   -2.47523400    0.00000000
+ H                 -2.14361600   -1.23761700    0.00000000
+ H                 -2.14361600    1.23761700    0.00000000
+}
+
+set {
+  basis sto-3g
+  scf_type pk
+  d_convergence      1e-10
+  maxiter 500
+  restricted_docc [ 6, 3, 0, 0, 0, 0, 5, 4 ]
+  active          [ 0, 0, 1, 2, 1, 2, 0, 0 ]
+}
+
+energy('hf')
+
+set v2rdm_casscf {
+# Note that when mcscf_rotate is set for the previous molecule, the calculations afterwards
+#   also use this input, unless you overwrite it. A safe way to unset it is to overwrite it
+#   with mcscf_rotate [[0, 0, 0, 0]], which should work as long as your molecule has at 
+#   least 1 orbital in the 1st irrep. This problem can also be simply avoided by calculating 
+#   the molecules that do not require orbital rotations first.
+  mcscf_rotate [[ 0, 0, 0, 0 ]]
+  positivity dq
+  r_convergence  1e-5
+  e_convergence  1e-6
+  maxiter 20000
+  guess_orbitals_write false
+  molden_write false
+}
+
+activate(benzene_d2h)
+
+E_d2h=energy('v2rdm-casscf')
+
+compare_values(E_c1, E_d2h, 4, "v2RDM-CASSCF total energy") # TEST
+
+--------------------------------------------------------------------------
+
+*** tstart() called on ed10
+*** at Thu Jun 14 17:08:23 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-6  entry C          line    61 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+    atoms 7-12 entry H          line    19 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: D2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     1.389804000000     0.000000000000    12.000000000000
+         C            1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         C            1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C            0.000000000000    -1.389804000000     0.000000000000    12.000000000000
+         C           -1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         H            0.000000000000     2.475234000000     0.000000000000     1.007825032070
+         H            2.143616000000     1.237617000000     0.000000000000     1.007825032070
+         H            2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H            0.000000000000    -2.475234000000     0.000000000000     1.007825032070
+         H           -2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -2.143616000000     1.237617000000     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.19143  B =      0.19143  C =      0.09572 [cm^-1]
+  Rotational constants: A =   5739.02343  B =   5739.01967  C =   2869.51077 [MHz]
+  Nuclear repulsion =  204.077021099348656
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 42
+  Nalpha       = 21
+  Nbeta        = 21
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 24
+    Number of basis function: 36
+    Number of Cartesian functions: 36
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         36      36       0       0       0       0
+   -------------------------------------------------------
+    Total      36      36      21      21      21       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                  12
+      Number of AO shells:              24
+      Number of primitives:             72
+      Number of atomic orbitals:        36
+      Number of basis functions:        36
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 444222 doubles for integral storage.
+  We computed 42486 shell quartets total.
+  Whereas there are 45150 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.6882920578E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -227.81707249348699   -2.27817e+02   9.82851e-02 
+   @RHF iter   1:  -227.76229457543545    5.47779e-02   1.05290e-02 
+   @RHF iter   2:  -227.88242405209854   -1.20129e-01   2.78780e-03 DIIS
+   @RHF iter   3:  -227.89087494235065   -8.45089e-03   6.83476e-04 DIIS
+   @RHF iter   4:  -227.89125016015802   -3.75218e-04   6.71109e-05 DIIS
+   @RHF iter   5:  -227.89125389414755   -3.73399e-06   9.19930e-06 DIIS
+   @RHF iter   6:  -227.89125401888194   -1.24734e-07   2.13968e-06 DIIS
+   @RHF iter   7:  -227.89125402703797   -8.15604e-09   5.91739e-07 DIIS
+   @RHF iter   8:  -227.89125402762659   -5.88614e-10   4.39275e-08 DIIS
+   @RHF iter   9:  -227.89125402762861   -2.01794e-12   3.88633e-09 DIIS
+   @RHF iter  10:  -227.89125402762994   -1.33582e-12   4.02875e-10 DIIS
+   @RHF iter  11:  -227.89125402763062   -6.82121e-13   3.62921e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -11.029219     2A    -11.029219     3A    -11.029203  
+       4A    -11.028834     5A    -11.028834     6A    -11.028676  
+       7A     -1.093407     8A     -0.956555     9A     -0.956555  
+      10A     -0.767676    11A     -0.767676    12A     -0.663690  
+      13A     -0.592995    14A     -0.555650    15A     -0.534819  
+      16A     -0.534819    17A     -0.459063    18A     -0.433032  
+      19A     -0.433032    20A     -0.281537    21A     -0.281537  
+
+    Virtual:                                                              
+
+      22A      0.270080    23A      0.270081    24A      0.507159  
+      25A      0.577151    26A      0.647784    27A      0.647785  
+      28A      0.724036    29A      0.739052    30A      0.739053  
+      31A      0.886660    32A      0.886661    33A      0.902363  
+      34A      0.902363    35A      1.094836    36A      1.158012  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    21 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -227.89125402763062
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =            204.0770210993486558
+    One-Electron Energy =                -712.9644967008534877
+    Two-Electron Energy =                 280.9962215738742088
+    Total Energy =                       -227.8912540276306231
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on ed10 at Thu Jun 14 17:08:24 2018
+Module time:
+	user time   =       1.57 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.57 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on ed10
+*** at Thu Jun 14 17:08:24 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-6  entry C          line    61 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+    atoms 7-12 entry H          line    19 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: D2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000000000000     1.389804000000     0.000000000000    12.000000000000
+         C            1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         C            1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -0.000000000000    -1.389804000000     0.000000000000    12.000000000000
+         C           -1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         H           -0.000000000000     2.475234000000     0.000000000000     1.007825032070
+         H            2.143616000000     1.237617000000     0.000000000000     1.007825032070
+         H            2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -0.000000000000    -2.475234000000     0.000000000000     1.007825032070
+         H           -2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -2.143616000000     1.237617000000     0.000000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.19143  B =      0.19143  C =      0.09572 [cm^-1]
+  Rotational constants: A =   5739.02343  B =   5739.01967  C =   2869.51077 [MHz]
+  Nuclear repulsion =  204.077021099348656
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 42
+  Nalpha       = 21
+  Nbeta        = 21
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 24
+    Number of basis function: 36
+    Number of Cartesian functions: 36
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         36      36       0       0       0       0
+   -------------------------------------------------------
+    Total      36      36      21      21      21       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                  12
+      Number of AO shells:              24
+      Number of primitives:             72
+      Number of atomic orbitals:        36
+      Number of basis functions:        36
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 444222 doubles for integral storage.
+  We computed 42486 shell quartets total.
+  Whereas there are 45150 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.6882920578E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -227.81707249348699   -2.27817e+02   9.82851e-02 
+   @RHF iter   1:  -227.76229457543536    5.47779e-02   1.05290e-02 
+   @RHF iter   2:  -227.88242405209874   -1.20129e-01   2.78780e-03 DIIS
+   @RHF iter   3:  -227.89087494235017   -8.45089e-03   6.83476e-04 DIIS
+   @RHF iter   4:  -227.89125016015754   -3.75218e-04   6.71109e-05 DIIS
+   @RHF iter   5:  -227.89125389414710   -3.73399e-06   9.19930e-06 DIIS
+   @RHF iter   6:  -227.89125401888231   -1.24735e-07   2.13968e-06 DIIS
+   @RHF iter   7:  -227.89125402703797   -8.15567e-09   5.91739e-07 DIIS
+   @RHF iter   8:  -227.89125402762636   -5.88386e-10   4.39275e-08 DIIS
+   @RHF iter   9:  -227.89125402762920   -2.84217e-12   3.88633e-09 DIIS
+   @RHF iter  10:  -227.89125402763023   -1.02318e-12   4.02874e-10 DIIS
+   @RHF iter  11:  -227.89125402762983    3.97904e-13   3.62921e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -11.029219     2A    -11.029219     3A    -11.029203  
+       4A    -11.028834     5A    -11.028834     6A    -11.028676  
+       7A     -1.093407     8A     -0.956555     9A     -0.956555  
+      10A     -0.767676    11A     -0.767676    12A     -0.663690  
+      13A     -0.592995    14A     -0.555650    15A     -0.534819  
+      16A     -0.534819    17A     -0.459063    18A     -0.433032  
+      19A     -0.433032    20A     -0.281537    21A     -0.281537  
+
+    Virtual:                                                              
+
+      22A      0.270080    23A      0.270081    24A      0.507159  
+      25A      0.577151    26A      0.647784    27A      0.647785  
+      28A      0.724036    29A      0.739052    30A      0.739053  
+      31A      0.886660    32A      0.886661    33A      0.902363  
+      34A      0.902363    35A      1.094836    36A      1.158012  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    21 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -227.89125402762983
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =            204.0770210993486558
+    One-Electron Energy =                -712.9644967008534877
+    Two-Electron Energy =                 280.9962215738750047
+    Total Energy =                       -227.8912540276298273
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on ed10 at Thu Jun 14 17:08:26 2018
+Module time:
+	user time   =       1.59 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       3.17 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                  12
+      Number of AO shells:              24
+      Number of SO shells:              24
+      Number of primitives:             72
+      Number of atomic orbitals:        36
+      Number of basis functions:        36
+
+      Number of irreps:                  1
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  36 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 134439 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+Reading options from the V2RDM_CASSCF block
+Calling plugin v2rdm_casscf.so.
+
+
+
+*** tstart() called on ed10
+*** at Thu Jun 14 17:08:27 2018
+
+
+
+        ****************************************************
+        *                                                  *
+        *    v2RDM-CASSCF                                  *
+        *                                                  *
+        *    A variational 2-RDM-driven approach to the    *
+        *    active space self-consistent field method     *
+        *                                                  *
+        ****************************************************
+
+
+        The following papers should be cited when using v2RDM-CASSCF:
+
+        J. Fosso-Tande, D. R. Nascimento, and A. E. DePrince III,
+        Mol. Phys. 114, 423-430 (2015).
+
+            URL: http://dx.doi.org/10.1080/00268976.2015.1078008
+
+        J. Fosso-Tande, T.-S. Nguyen, G. Gidofalvi, and
+        A. E. DePrince III, J. Chem. Theory Comput. accepted (2016).
+
+            URL: http://dx.doi.org/10.1021/acs.jctc.6b00190
+
+
+
+  ==> Convergence parameters <==
+
+        r_convergence:                      1.000e-05
+        e_convergence:                      1.000e-06
+        cg_convergence:                     1.000e-09
+        maxiter:                                20000
+        cg_maxiter:                             10000
+
+  ==> Active space details <==
+
+        Number of frozen core orbitals:             0
+        Number of restricted occupied orbitals:    18
+        Number of active occupied orbitals:         3
+        Number of active virtual orbitals:          3
+        Number of restricted virtual orbitals:     12
+        Number of frozen virtual orbitals:          0
+
+        Irrep:              A 
+ 
+        frozen_docc     [   0 ]
+        restricted_docc [  18 ]
+        active          [   6 ]
+        restricted_uocc [  12 ]
+        frozen_uocc     [   0 ]
+
+  ==> Orbital optimization parameters <==
+
+        1-step algorithm:                    true
+        g_convergence:                  1.000e-06
+        e_convergence:                  1.000e-08
+        maximum iterations:                    20
+        frequency:                            500
+        active-active rotations:            false
+        exact diagonal Hessian:             false
+        number of DIIS vectors:                 0
+        print iteration info:               false
+
+  ==> Memory requirements <==
+
+        D2:                          0.01 mb
+        Q2:                          0.01 mb
+
+        Total number of variables:           4932
+        Total number of constraints:         3973
+        Total memory requirements:        2.35 mb
+
+    ==> Transform two-electron integrals <==
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+        Time for integral transformation:     0.30 s
+
+    Molecular point group: c1
+    Full point group: D2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000000000000     1.389804000000     0.000000000000    12.000000000000
+         C            1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         C            1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -0.000000000000    -1.389804000000     0.000000000000    12.000000000000
+         C           -1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         H           -0.000000000000     2.475234000000     0.000000000000     1.007825032070
+         H            2.143616000000     1.237617000000     0.000000000000     1.007825032070
+         H            2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -0.000000000000    -2.475234000000     0.000000000000     1.007825032070
+         H           -2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -2.143616000000     1.237617000000     0.000000000000     1.007825032070
+
+  -AO BASIS SET INFORMATION:
+    Name                   = STO-3G
+    Blend                  = STO-3G
+    Total number of shells = 24
+    Number of primitives   = 72
+    Number of AO           = 36
+    Number of SO           = 36
+    Maximum AM             = 1
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     C     6s 3p // 2s 1p 
+       2     C     6s 3p // 2s 1p 
+       3     C     6s 3p // 2s 1p 
+       4     C     6s 3p // 2s 1p 
+       5     C     6s 3p // 2s 1p 
+       6     C     6s 3p // 2s 1p 
+       7     H     3s // 1s 
+       8     H     3s // 1s 
+       9     H     3s // 1s 
+      10     H     3s // 1s 
+      11     H     3s // 1s 
+      12     H     3s // 1s 
+
+  ==> AO Basis Functions <==
+
+    [ STO-3G ]
+    spherical
+    ****
+    C   1
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    C   2
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    C   3
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    C   4
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    C   5
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    C   6
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    H   7
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+    H   8
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+    H   9
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+    H  10
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+    H  11
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+    H  12
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+
+
+        Read integrals......done.
+
+
+    reference energy:        -227.891254027630
+    frozen core energy:      -425.567881696744
+    initial 2-RDM energy:    -225.463643727025
+
+      oiter iiter        E(p)        E(d)      E gap)      mu     eps(p)     eps(d)
+          0    47 -205.329478  -41.437969 1.638915e+02   1.000 1.98456e+02 1.43251e+02
+          1    28 -223.490253 -590.170147 3.666799e+02   1.000 1.33312e+01 9.06576e+01
+          2    29 -222.779466 -373.583818 1.508044e+02   1.000 1.22573e+01 3.36639e+00
+          3    27 -229.860260 -354.944327 1.250841e+02   1.000 1.15881e+01 2.80982e+00
+          4    28 -229.845832 -344.011986 1.141662e+02   1.000 1.06699e+01 2.40000e+00
+          5    28 -229.666866 -330.411748 1.007449e+02   1.000 1.02197e+01 1.64692e+00
+          6    28 -229.476827 -318.714087 8.923726e+01   1.000 9.28807e+00 1.09542e+00
+          7    28 -229.131962 -307.921993 7.879003e+01   1.000 8.29742e+00 1.02528e+00
+          8    28 -228.859561 -298.587244 6.972768e+01   1.000 7.32914e+00 8.61710e-01
+          9    28 -228.564168 -289.656880 6.109271e+01   1.000 6.44399e+00 8.67541e-01
+         10    28 -228.281523 -281.781821 5.350030e+01   1.000 5.58128e+00 8.06451e-01
+         11    28 -228.217509 -274.722139 4.650463e+01   1.000 5.34448e+00 6.95284e-01
+         12    28 -228.113804 -267.818324 3.970452e+01   1.000 4.86373e+00 5.96300e-01
+         13    28 -227.865460 -261.342178 3.347672e+01   1.000 4.01246e+00 7.66290e-01
+         14    28 -227.849757 -255.884984 2.803523e+01   1.000 3.73048e+00 7.40068e-01
+         15    28 -227.639481 -250.801666 2.316219e+01   1.000 3.00293e+00 1.05301e+00
+         16    28 -227.442982 -247.774790 2.033181e+01   1.000 2.39513e+00 7.71846e-01
+         17    28 -227.420839 -244.132883 1.671204e+01   1.000 2.16616e+00 6.50389e-01
+         18    28 -227.402936 -241.399341 1.399640e+01   1.000 1.96951e+00 6.12212e-01
+         19    28 -227.363278 -238.358016 1.099474e+01   1.000 1.80039e+00 5.63507e-01
+         20    28 -227.337840 -235.840998 8.503159e+00   1.000 1.69005e+00 4.45813e-01
+         21    28 -227.367244 -233.419134 6.051890e+00   1.000 1.69374e+00 4.53732e-01
+         22    28 -227.398615 -231.448646 4.050032e+00   1.000 1.61220e+00 4.67063e-01
+         23    28 -227.338377 -229.583905 2.245528e+00   1.000 1.32794e+00 5.49689e-01
+         24    28 -227.360523 -228.193264 8.327401e-01   1.000 1.10920e+00 5.94672e-01
+         25    28 -227.289431 -227.218767 7.066431e-02   1.000 7.13010e-01 8.30884e-01
+         26    22 -227.333368 -227.257656 7.571164e-02   1.000 4.65282e-01 6.33924e-01
+         27    24 -227.419352 -227.281456 1.378959e-01   1.000 3.09649e-01 3.90157e-01
+         28    24 -227.482175 -227.414600 6.757465e-02   1.000 2.35481e-01 2.89321e-01
+         29    24 -227.537193 -227.426884 1.103089e-01   1.000 1.65064e-01 2.30994e-01
+         30    24 -227.573274 -227.467725 1.055491e-01   1.000 1.25409e-01 1.97109e-01
+         31    23 -227.598589 -227.461632 1.369572e-01   1.000 1.00184e-01 1.72654e-01
+         32    23 -227.616219 -227.501283 1.149361e-01   1.000 1.16288e-01 1.55545e-01
+         33    21 -227.639825 -227.540271 9.955365e-02   1.000 1.02291e-01 1.42760e-01
+         34    22 -227.665551 -227.566327 9.922401e-02   1.000 6.49671e-02 1.38087e-01
+         35    22 -227.682306 -227.583566 9.873945e-02   1.000 3.77124e-02 1.34197e-01
+         36    23 -227.701144 -227.585229 1.159152e-01   1.000 4.44753e-02 1.28239e-01
+         37    21 -227.712618 -227.582584 1.300341e-01   1.000 4.39661e-02 1.23161e-01
+         38    22 -227.724217 -227.578018 1.461997e-01   1.000 3.32954e-02 1.19345e-01
+         39    22 -227.734039 -227.575356 1.586825e-01   1.000 2.59066e-02 1.16441e-01
+         40    23 -227.745366 -227.576746 1.686202e-01   1.000 2.65190e-02 1.13889e-01
+         41    23 -227.757800 -227.584888 1.729116e-01   1.000 2.83816e-02 1.11115e-01
+         42    23 -227.770899 -227.596039 1.748596e-01   1.000 2.65412e-02 1.08283e-01
+         43    21 -227.783778 -227.607747 1.760306e-01   1.000 2.28474e-02 1.05962e-01
+         44    23 -227.795581 -227.618665 1.769158e-01   1.000 1.96209e-02 1.04108e-01
+         45    22 -227.806015 -227.628939 1.770756e-01   1.000 1.77043e-02 1.02395e-01
+         46    24 -227.812336 -227.641138 1.711976e-01   1.000 2.80445e-02 9.89716e-02
+         47    21 -227.819361 -227.670846 1.485150e-01   1.000 3.00405e-02 9.57576e-02
+         48    21 -227.826361 -227.689101 1.372604e-01   1.000 2.79405e-02 9.33206e-02
+         49    21 -227.832887 -227.696223 1.366640e-01   1.000 3.11304e-02 8.96656e-02
+         50    22 -227.840752 -227.708385 1.323673e-01   1.000 2.95295e-02 8.63585e-02
+         51    22 -227.848777 -227.717200 1.315764e-01   1.000 2.67607e-02 8.40414e-02
+         52    22 -227.855810 -227.725111 1.306982e-01   1.000 2.43170e-02 8.19105e-02
+         53    21 -227.863076 -227.734549 1.285266e-01   1.000 2.14546e-02 7.99680e-02
+         54    22 -227.870066 -227.740097 1.299687e-01   1.000 1.92769e-02 7.81575e-02
+         55    24 -227.876240 -227.744618 1.316216e-01   1.000 1.80171e-02 7.62810e-02
+         56    24 -227.881457 -227.752750 1.287074e-01   1.000 1.76641e-02 7.42883e-02
+         57    24 -227.886689 -227.763409 1.232793e-01   1.000 1.63606e-02 7.26053e-02
+         58    23 -227.891654 -227.770529 1.211255e-01   1.000 1.53214e-02 7.10964e-02
+         59    23 -227.896578 -227.776750 1.198278e-01   1.000 1.52664e-02 6.96122e-02
+         60    23 -227.901476 -227.784746 1.167304e-01   1.000 1.57796e-02 6.80471e-02
+         61    24 -227.906249 -227.790314 1.159354e-01   1.000 1.62004e-02 6.66338e-02
+         62    23 -227.910296 -227.794622 1.156735e-01   1.000 1.59449e-02 6.53538e-02
+         63    22 -227.914567 -227.797956 1.166116e-01   1.000 1.59303e-02 6.41577e-02
+         64    24 -227.918276 -227.800623 1.176535e-01   1.000 1.53382e-02 6.30642e-02
+         65    21 -227.921930 -227.803173 1.187567e-01   1.000 1.45022e-02 6.21064e-02
+         66    21 -227.925294 -227.805864 1.194307e-01   1.000 1.32884e-02 6.12823e-02
+         67    21 -227.928603 -227.809060 1.195426e-01   1.000 1.19472e-02 6.05545e-02
+         68    23 -227.931804 -227.812769 1.190350e-01   1.000 1.06827e-02 5.98566e-02
+         69    23 -227.934960 -227.818064 1.168954e-01   1.000 1.00514e-02 5.91183e-02
+         70    23 -227.938307 -227.823677 1.146296e-01   1.000 1.02769e-02 5.83650e-02
+         71    23 -227.941353 -227.827692 1.136609e-01   1.000 1.07737e-02 5.75531e-02
+         72    24 -227.944100 -227.830785 1.133148e-01   1.000 1.09607e-02 5.66439e-02
+         73    24 -227.946792 -227.834743 1.120492e-01   1.000 1.09911e-02 5.57384e-02
+         74    24 -227.949458 -227.837187 1.122715e-01   1.000 1.04846e-02 5.51132e-02
+         75    24 -227.951991 -227.838483 1.135072e-01   1.000 9.59566e-03 5.46282e-02
+         76    24 -227.954181 -227.838859 1.153222e-01   1.000 9.08321e-03 5.41318e-02
+         77    24 -227.956514 -227.839123 1.173902e-01   1.000 9.63444e-03 5.34473e-02
+         78    24 -227.959225 -227.840934 1.182910e-01   1.000 9.92069e-03 5.25795e-02
+         79    23 -227.962107 -227.841466 1.206408e-01   1.000 9.43521e-03 5.20078e-02
+         80    23 -227.965050 -227.841243 1.238070e-01   1.000 8.37376e-03 5.17182e-02
+         81    23 -227.967883 -227.841047 1.268358e-01   1.000 7.22704e-03 5.15297e-02
+         82    23 -227.970632 -227.841804 1.288282e-01   1.000 6.51489e-03 5.12826e-02
+         83    23 -227.973338 -227.844495 1.288431e-01   1.000 6.73741e-03 5.08430e-02
+         84    23 -227.975769 -227.846014 1.297546e-01   1.000 7.14913e-03 5.03882e-02
+         85    21 -227.978095 -227.848876 1.292195e-01   1.000 7.53467e-03 4.99644e-02
+         86    21 -227.980365 -227.851171 1.291942e-01   1.000 7.74856e-03 4.95789e-02
+         87    21 -227.982643 -227.853650 1.289923e-01   1.000 7.87883e-03 4.91897e-02
+         88    21 -227.984910 -227.855722 1.291880e-01   1.000 8.00439e-03 4.87611e-02
+         89    21 -227.987210 -227.857869 1.293404e-01   1.000 8.22419e-03 4.82858e-02
+         90    23 -227.989447 -227.860127 1.293201e-01   1.000 8.52965e-03 4.77800e-02
+         91    22 -227.991787 -227.862898 1.288889e-01   1.000 8.72437e-03 4.72639e-02
+         92    24 -227.993875 -227.865983 1.278921e-01   1.000 8.76881e-03 4.67487e-02
+         93    24 -227.996012 -227.869921 1.260911e-01   1.000 8.65341e-03 4.62234e-02
+         94    24 -227.997584 -227.873771 1.238128e-01   1.000 9.75107e-03 4.55774e-02
+         95    21 -227.999227 -227.878932 1.202946e-01   1.000 1.08874e-02 4.46583e-02
+         96    24 -228.000891 -227.887725 1.131654e-01   1.000 1.29539e-02 4.32820e-02
+         97    24 -228.001860 -227.895863 1.059974e-01   1.000 1.66511e-02 4.03552e-02
+         98    21 -228.003753 -227.913055 9.069784e-02   1.000 1.45704e-02 3.91057e-02
+         99    22 -228.005511 -227.923835 8.167598e-02   1.000 1.23235e-02 3.78566e-02
+        100    24 -228.006577 -227.930059 7.651808e-02   1.000 1.20103e-02 3.64538e-02
+        101    23 -228.007198 -227.933939 7.325840e-02   1.000 1.33270e-02 3.53363e-02
+        102    24 -228.007876 -227.935823 7.205323e-02   1.000 1.42857e-02 3.44881e-02
+        103    21 -228.008883 -227.937286 7.159700e-02   1.000 1.35343e-02 3.37879e-02
+        104    22 -228.010260 -227.940085 7.017469e-02   1.000 1.15255e-02 3.30345e-02
+        105    22 -228.011486 -227.941474 7.001160e-02   1.000 9.95047e-03 3.22890e-02
+        106    23 -228.012837 -227.943094 6.974367e-02   1.000 8.53351e-03 3.15910e-02
+        107    22 -228.014011 -227.943807 7.020420e-02   1.000 7.61624e-03 3.09570e-02
+        108    23 -228.015167 -227.944909 7.025764e-02   1.000 7.03563e-03 3.03691e-02
+        109    22 -228.015803 -227.946219 6.958415e-02   1.000 7.45604e-03 2.97892e-02
+        110    23 -228.016511 -227.949093 6.741855e-02   1.000 8.01424e-03 2.92794e-02
+        111    23 -228.017361 -227.952003 6.535889e-02   1.000 7.75400e-03 2.88942e-02
+        112    23 -228.018331 -227.954395 6.393601e-02   1.000 6.76546e-03 2.86361e-02
+        113    21 -228.019309 -227.956183 6.312693e-02   1.000 5.60698e-03 2.84446e-02
+        114    23 -228.020263 -227.957691 6.257157e-02   1.000 4.72573e-03 2.82717e-02
+        115    24 -228.021093 -227.958174 6.291931e-02   1.000 4.34334e-03 2.80863e-02
+        116    24 -228.021856 -227.958566 6.328938e-02   1.000 4.22820e-03 2.78718e-02
+        117    24 -228.022491 -227.958426 6.406562e-02   1.000 4.08061e-03 2.76531e-02
+        118    24 -228.023131 -227.958228 6.490301e-02   1.000 3.84175e-03 2.74395e-02
+        119    24 -228.023787 -227.958280 6.550734e-02   1.000 3.48379e-03 2.72292e-02
+        120    23 -228.024522 -227.958848 6.567420e-02   1.000 3.11005e-03 2.70182e-02
+        121    22 -228.025284 -227.959941 6.534314e-02   1.000 2.83556e-03 2.68034e-02
+        122    23 -228.026056 -227.960967 6.508930e-02   1.000 2.73376e-03 2.65867e-02
+        123    23 -228.026796 -227.961856 6.493925e-02   1.000 2.75510e-03 2.63753e-02
+        124    23 -228.027487 -227.962552 6.493525e-02   1.000 2.80044e-03 2.61743e-02
+        125    22 -228.028156 -227.963099 6.505655e-02   1.000 2.83823e-03 2.59855e-02
+        126    23 -228.028778 -227.963535 6.524294e-02   1.000 2.89190e-03 2.58080e-02
+        127    23 -228.029401 -227.963879 6.552212e-02   1.000 2.98645e-03 2.56404e-02
+        128    23 -228.030005 -227.964178 6.582685e-02   1.000 3.10703e-03 2.54818e-02
+        129    23 -228.030632 -227.964465 6.616608e-02   1.000 3.21735e-03 2.53311e-02
+        130    21 -228.031263 -227.964797 6.646569e-02   1.000 3.27578e-03 2.51869e-02
+        131    24 -228.031907 -227.965190 6.671693e-02   1.000 3.25275e-03 2.50470e-02
+        132    24 -228.032564 -227.965664 6.690001e-02   1.000 3.15399e-03 2.49087e-02
+        133    24 -228.033226 -227.966208 6.701802e-02   1.000 2.99771e-03 2.47683e-02
+        134    24 -228.033888 -227.966815 6.707302e-02   1.000 2.83056e-03 2.46224e-02
+        135    24 -228.034538 -227.967466 6.707206e-02   1.000 2.69209e-03 2.44678e-02
+        136    24 -228.035176 -227.968144 6.703185e-02   1.000 2.62154e-03 2.43018e-02
+        137    24 -228.035787 -227.968832 6.695472e-02   1.000 2.63257e-03 2.41224e-02
+        138    24 -228.036379 -227.969515 6.686423e-02   1.000 2.73842e-03 2.39273e-02
+        139    24 -228.036949 -227.970276 6.667255e-02   1.000 3.33478e-03 2.36024e-02
+        140    24 -228.036437 -227.972443 6.399373e-02   1.000 9.93476e-03 2.25676e-02
+        141    24 -228.036035 -227.980467 5.556769e-02   1.000 1.60920e-02 2.09888e-02
+        142    21 -228.035929 -227.987534 4.839535e-02   1.000 2.17544e-02 1.97345e-02
+        143    21 -228.036233 -227.993140 4.309343e-02   1.000 2.47992e-02 1.84635e-02
+        144    22 -228.036603 -227.997346 3.925700e-02   1.000 2.64283e-02 1.72622e-02
+        145    24 -228.036955 -228.002336 3.461914e-02   1.000 2.63420e-02 1.64757e-02
+        146    21 -228.037487 -228.008510 2.897720e-02   1.000 2.47083e-02 1.60923e-02
+        147    23 -228.038212 -228.014570 2.364169e-02   1.000 2.13308e-02 1.59054e-02
+        148    22 -228.039142 -228.019133 2.000871e-02   1.000 1.70806e-02 1.57338e-02
+        149    21 -228.040054 -228.022138 1.791539e-02   1.000 1.26105e-02 1.54547e-02
+        150    22 -228.040900 -228.024158 1.674202e-02   1.000 9.30917e-03 1.49953e-02
+        151    21 -228.041547 -228.025034 1.651265e-02   1.000 8.03515e-03 1.43944e-02
+        152    22 -228.041574 -228.025203 1.637064e-02   1.000 7.49169e-03 1.38031e-02
+        153    21 -228.041704 -228.026259 1.544550e-02   1.000 9.29530e-03 1.31077e-02
+        154    21 -228.041663 -228.026353 1.530995e-02   1.000 1.05575e-02 1.25361e-02
+        155    18 -228.041622 -228.025901 1.572092e-02   1.000 1.08575e-02 1.20905e-02
+        156    18 -228.041491 -228.023904 1.758723e-02   1.000 1.00136e-02 1.17658e-02
+        157    19 -228.041219 -228.020927 2.029141e-02   1.000 8.24469e-03 1.14694e-02
+        158    20 -228.040619 -228.018300 2.231849e-02   1.000 6.56302e-03 1.09649e-02
+        159    22 -228.040145 -228.019098 2.104697e-02   1.000 5.89076e-03 1.02582e-02
+        160    22 -228.039930 -228.021337 1.859298e-02   1.000 5.78343e-03 9.51371e-03
+        161    22 -228.039913 -228.023706 1.620688e-02   1.000 5.81053e-03 8.87459e-03
+        162    22 -228.039983 -228.025823 1.415948e-02   1.000 5.84648e-03 8.41420e-03
+        163    22 -228.040132 -228.027491 1.264141e-02   1.000 5.79380e-03 8.09381e-03
+        164    22 -228.040271 -228.028902 1.136851e-02   1.000 5.47022e-03 7.87495e-03
+        165    22 -228.040474 -228.030122 1.035183e-02   1.000 4.74507e-03 7.70388e-03
+        166    22 -228.040738 -228.031111 9.626974e-03   1.000 3.78623e-03 7.51699e-03
+        167    22 -228.041066 -228.031665 9.401176e-03   1.000 3.05148e-03 7.28435e-03
+        168    22 -228.041399 -228.031640 9.759052e-03   1.000 3.03397e-03 7.01305e-03
+        169    22 -228.041694 -228.031044 1.064981e-02   1.000 3.50575e-03 6.72701e-03
+        170    22 -228.041823 -228.030128 1.169436e-02   1.000 3.55709e-03 6.45865e-03
+        171    22 -228.041944 -228.029493 1.245101e-02   1.000 3.68994e-03 6.20530e-03
+        172    22 -228.041917 -228.028944 1.297257e-02   1.000 3.20937e-03 5.98755e-03
+        173    22 -228.041797 -228.029353 1.244344e-02   1.000 2.64668e-03 5.80265e-03
+        174    22 -228.041663 -228.030511 1.115267e-02   1.000 2.19982e-03 5.64071e-03
+        175    21 -228.041514 -228.032127 9.386327e-03   1.000 1.92594e-03 5.49699e-03
+        176    23 -228.041382 -228.033893 7.488982e-03   1.000 1.78168e-03 5.36558e-03
+        177    22 -228.041274 -228.035420 5.853626e-03   1.000 1.62193e-03 5.24177e-03
+        178    23 -228.041198 -228.036459 4.738441e-03   1.000 1.44430e-03 5.11799e-03
+        179    21 -228.041135 -228.036945 4.190296e-03   1.000 1.27940e-03 4.98618e-03
+        180    22 -228.041078 -228.036943 4.134708e-03   1.000 1.18611e-03 4.84307e-03
+        181    21 -228.041027 -228.036611 4.415883e-03   1.000 1.16985e-03 4.69296e-03
+        182    21 -228.040988 -228.036112 4.875407e-03   1.000 1.20463e-03 4.54564e-03
+        183    22 -228.040938 -228.035577 5.360663e-03   1.000 1.29071e-03 4.41179e-03
+        184    22 -228.040920 -228.035136 5.784111e-03   1.000 1.39226e-03 4.29959e-03
+        185    22 -228.040927 -228.034763 6.164691e-03   1.000 1.48422e-03 4.20911e-03
+        186    21 -228.040962 -228.034510 6.452511e-03   1.000 1.54937e-03 4.13402e-03
+        187    21 -228.041017 -228.034442 6.575430e-03   1.000 1.57216e-03 4.06586e-03
+        188    21 -228.041085 -228.034554 6.530786e-03   1.000 1.54738e-03 3.99665e-03
+        189    21 -228.041168 -228.034815 6.352938e-03   1.000 1.47667e-03 3.92236e-03
+        190    22 -228.041247 -228.035179 6.068247e-03   1.000 1.38275e-03 3.84313e-03
+        191    21 -228.041329 -228.035590 5.738518e-03   1.000 1.28559e-03 3.76190e-03
+        192    20 -228.041392 -228.036014 5.378062e-03   1.000 1.21209e-03 3.68230e-03
+        193    21 -228.041445 -228.036404 5.040555e-03   1.000 1.17453e-03 3.60719e-03
+        194    21 -228.041486 -228.036734 4.752161e-03   1.000 1.17539e-03 3.53802e-03
+        195    21 -228.041508 -228.036980 4.527534e-03   1.000 1.19271e-03 3.47478e-03
+        196    21 -228.041502 -228.037130 4.372222e-03   1.000 1.16952e-03 3.41690e-03
+        197    22 -228.041487 -228.037225 4.261848e-03   1.000 1.13588e-03 3.36234e-03
+        198    22 -228.041454 -228.037223 4.231583e-03   1.000 1.07404e-03 3.31000e-03
+        199    21 -228.041424 -228.037185 4.239233e-03   1.000 1.02810e-03 3.25760e-03
+        200    20 -228.041394 -228.037106 4.287494e-03   1.000 1.00613e-03 3.20472e-03
+        201    21 -228.041370 -228.037045 4.324670e-03   1.000 1.01442e-03 3.15179e-03
+        202    20 -228.041361 -228.037005 4.355517e-03   1.000 1.03897e-03 3.09947e-03
+        203    21 -228.041365 -228.037007 4.358565e-03   1.000 1.06283e-03 3.04753e-03
+        204    20 -228.041309 -228.037043 4.266058e-03   1.000 1.24243e-03 2.58481e-03
+        205    19 -228.041226 -228.038004 3.221971e-03   1.000 1.90791e-03 1.91382e-03
+        206    19 -228.041318 -228.040497 8.213865e-04   1.000 1.84793e-03 1.84351e-03
+        207    21 -228.041464 -228.042122 6.576279e-04   1.000 1.57847e-03 1.67245e-03
+        208    21 -228.041541 -228.042440 8.986954e-04   1.000 1.44387e-03 1.64123e-03
+        209    22 -228.041596 -228.042041 4.444741e-04   1.000 1.42389e-03 1.57842e-03
+        210    21 -228.041596 -228.041243 3.534386e-04   1.000 1.36372e-03 1.51619e-03
+        211    20 -228.041574 -228.040487 1.087361e-03   1.000 1.23330e-03 1.46971e-03
+        212    22 -228.041542 -228.040020 1.521317e-03   1.000 1.08742e-03 1.43443e-03
+        213    21 -228.041516 -228.039880 1.635880e-03   1.000 9.63350e-04 1.40843e-03
+        214    22 -228.041495 -228.039959 1.535526e-03   1.000 8.60521e-04 1.39292e-03
+        215    22 -228.041479 -228.040140 1.339201e-03   1.000 7.90355e-04 1.38072e-03
+        216    22 -228.041466 -228.040338 1.127287e-03   1.000 7.68706e-04 1.36046e-03
+        217    21 -228.041452 -228.040527 9.245955e-04   1.000 7.84652e-04 1.32868e-03
+        218    21 -228.041423 -228.040710 7.131629e-04   1.000 8.47992e-04 1.28993e-03
+        219    22 -228.041396 -228.040941 4.549874e-04   1.000 9.04028e-04 1.25422e-03
+        220    21 -228.041382 -228.041149 2.325167e-04   1.000 9.07816e-04 1.22826e-03
+        221    21 -228.041379 -228.041295 8.316177e-05   1.000 8.61121e-04 1.20865e-03
+        222    21 -228.041388 -228.041376 1.207735e-05   1.000 7.81969e-04 1.19214e-03
+        223    21 -228.041408 -228.041385 2.287538e-05   1.000 7.01099e-04 1.17707e-03
+        224    20 -228.041436 -228.041312 1.239099e-04   1.000 6.51474e-04 1.16242e-03
+        225    22 -228.041463 -228.041167 2.965851e-04   1.000 6.48579e-04 1.14789e-03
+        226    20 -228.041493 -228.040978 5.145411e-04   1.000 6.77057e-04 1.13363e-03
+        227    19 -228.041515 -228.040796 7.192480e-04   1.000 7.08193e-04 1.11971e-03
+        228    20 -228.041529 -228.040660 8.689660e-04   1.000 7.23692e-04 1.10579e-03
+        229    21 -228.041540 -228.040600 9.398809e-04   1.000 7.21893e-04 1.09155e-03
+        230    21 -228.041536 -228.040618 9.178722e-04   1.000 6.70147e-04 1.07775e-03
+        231    21 -228.041527 -228.040721 8.059075e-04   1.000 6.23641e-04 1.06498e-03
+        232    21 -228.041522 -228.040848 6.735241e-04   1.000 5.81054e-04 1.05347e-03
+        233    21 -228.041511 -228.040964 5.464229e-04   1.000 5.50859e-04 1.04346e-03
+        234    20 -228.041505 -228.041065 4.401338e-04   1.000 5.32861e-04 1.03465e-03
+        235    20 -228.041500 -228.041136 3.639046e-04   1.000 5.21091e-04 1.02654e-03
+        236    20 -228.041497 -228.041176 3.211947e-04   1.000 5.12216e-04 1.01857e-03
+        237    20 -228.041495 -228.041185 3.102429e-04   1.000 5.04298e-04 1.01049e-03
+        238    20 -228.041493 -228.041171 3.227868e-04   1.000 4.97120e-04 1.00231e-03
+        239    19 -228.041492 -228.041142 3.504590e-04   1.000 4.90449e-04 9.94225e-04
+        240    20 -228.041491 -228.041107 3.838595e-04   1.000 4.83995e-04 9.86407e-04
+        241    19 -228.041490 -228.041077 4.130831e-04   1.000 4.77607e-04 9.78993e-04
+        242    20 -228.041489 -228.041054 4.346512e-04   1.000 4.71188e-04 9.72090e-04
+        243    19 -228.041489 -228.041046 4.433076e-04   1.000 4.64862e-04 9.65775e-04
+        244    20 -228.041490 -228.041050 4.406104e-04   1.000 4.58368e-04 9.60043e-04
+        245    20 -228.041493 -228.041063 4.301841e-04   1.000 4.51908e-04 9.54767e-04
+        246    20 -228.041498 -228.041082 4.162288e-04   1.000 4.45821e-04 9.49723e-04
+        247    20 -228.041503 -228.041100 4.022048e-04   1.000 4.40622e-04 9.44685e-04
+        248    19 -228.041510 -228.041115 3.952498e-04   1.000 4.36997e-04 9.39530e-04
+        249    20 -228.041513 -228.041130 3.837057e-04   1.000 4.34425e-04 9.34278e-04
+        250    20 -228.041519 -228.041137 3.816551e-04   1.000 4.32666e-04 9.29049e-04
+        251    20 -228.041521 -228.041144 3.775368e-04   1.000 4.30843e-04 9.23988e-04
+        252    20 -228.041523 -228.041149 3.741110e-04   1.000 4.28336e-04 9.19194e-04
+        253    21 -228.041525 -228.041157 3.680211e-04   1.000 4.24890e-04 9.14702e-04
+        254    21 -228.041524 -228.041165 3.590516e-04   1.000 4.20159e-04 9.10494e-04
+        255    20 -228.041523 -228.041175 3.482379e-04   1.000 4.14490e-04 9.06534e-04
+        256    21 -228.041522 -228.041185 3.363389e-04   1.000 4.07888e-04 9.02781e-04
+        257    21 -228.041520 -228.041195 3.257551e-04   1.000 4.01231e-04 8.99192e-04
+        258    20 -228.041518 -228.041202 3.158411e-04   1.000 3.94076e-04 8.95729e-04
+        259    19 -228.041518 -228.041207 3.105928e-04   1.000 3.87880e-04 8.92354e-04
+        260    20 -228.041517 -228.041210 3.068540e-04   1.000 3.81813e-04 8.89045e-04
+        261    20 -228.041516 -228.041210 3.056687e-04   1.000 3.76285e-04 8.85797e-04
+        262    20 -228.041516 -228.041209 3.069113e-04   1.000 3.71423e-04 8.82625e-04
+        263    21 -228.041517 -228.041209 3.076357e-04   1.000 3.66878e-04 8.79548e-04
+        264    20 -228.041517 -228.041210 3.066570e-04   1.000 3.62388e-04 8.76580e-04
+        265    19 -228.041518 -228.041213 3.046408e-04   1.000 3.58278e-04 8.73723e-04
+        266    20 -228.041519 -228.041219 3.004699e-04   1.000 3.54352e-04 8.70968e-04
+        267    22 -228.041520 -228.041228 2.925982e-04   1.000 3.50589e-04 8.68301e-04
+        268    20 -228.041522 -228.041237 2.848474e-04   1.000 3.47334e-04 8.65705e-04
+        269    19 -228.041523 -228.041248 2.745227e-04   1.000 3.43963e-04 8.63168e-04
+        270    20 -228.041525 -228.041258 2.668254e-04   1.000 3.41481e-04 8.60682e-04
+        271    19 -228.041526 -228.041268 2.578645e-04   1.000 3.38670e-04 8.58247e-04
+        272    21 -228.041527 -228.041274 2.526545e-04   1.000 3.36089e-04 8.55862e-04
+        273    20 -228.041528 -228.041279 2.496854e-04   1.000 3.33928e-04 8.53538e-04
+        274    21 -228.041528 -228.041281 2.474006e-04   1.000 3.30844e-04 8.51281e-04
+        275    21 -228.041529 -228.041281 2.482735e-04   1.000 3.28041e-04 8.49098e-04
+        276    21 -228.041529 -228.041280 2.487373e-04   1.000 3.24339e-04 8.46994e-04
+        277    21 -228.041529 -228.041279 2.502105e-04   1.000 3.20602e-04 8.44965e-04
+        278    21 -228.041529 -228.041278 2.507219e-04   1.000 3.16523e-04 8.43006e-04
+        279    21 -228.041530 -228.041279 2.508738e-04   1.000 3.12728e-04 8.41105e-04
+        280    21 -228.041530 -228.041281 2.484344e-04   1.000 3.08417e-04 8.39254e-04
+        281    20 -228.041530 -228.041284 2.460785e-04   1.000 3.04564e-04 8.37443e-04
+        282    21 -228.041530 -228.041289 2.414801e-04   1.000 3.00420e-04 8.35667e-04
+        283    21 -228.041530 -228.041293 2.369986e-04   1.000 2.96712e-04 8.33926e-04
+        284    20 -228.041531 -228.041299 2.319507e-04   1.000 2.93272e-04 8.32217e-04
+        285    20 -228.041531 -228.041305 2.263862e-04   1.000 2.89915e-04 8.30544e-04
+        286    22 -228.041532 -228.041310 2.216178e-04   1.000 2.86896e-04 8.28906e-04
+        287    20 -228.041532 -228.041315 2.167877e-04   1.000 2.83861e-04 8.27303e-04
+        288    22 -228.041533 -228.041320 2.136936e-04   1.000 2.81163e-04 8.25734e-04
+        289    20 -228.041533 -228.041324 2.097829e-04   1.000 2.78376e-04 8.24198e-04
+        290    21 -228.041535 -228.041327 2.084815e-04   1.000 2.76127e-04 8.22692e-04
+        291    21 -228.041536 -228.041330 2.056685e-04   1.000 2.73664e-04 8.21213e-04
+        292    20 -228.041536 -228.041332 2.044199e-04   1.000 2.71324e-04 8.19761e-04
+        293    20 -228.041537 -228.041334 2.030931e-04   1.000 2.68880e-04 8.18335e-04
+        294    22 -228.041538 -228.041335 2.029249e-04   1.000 2.66766e-04 8.16935e-04
+        295    19 -228.041539 -228.041337 2.017397e-04   1.000 2.64443e-04 8.15563e-04
+        296    21 -228.041540 -228.041338 2.016681e-04   1.000 2.62151e-04 8.14217e-04
+        297    21 -228.041540 -228.041339 2.004682e-04   1.000 2.59583e-04 8.12899e-04
+        298    21 -228.041541 -228.041341 2.001375e-04   1.000 2.57114e-04 8.11609e-04
+        299    21 -228.041541 -228.041342 1.986675e-04   1.000 2.54293e-04 8.10344e-04
+        300    20 -228.041542 -228.041344 1.981048e-04   1.000 2.51892e-04 8.09103e-04
+        301    21 -228.041542 -228.041346 1.956307e-04   1.000 2.48809e-04 8.07885e-04
+        302    21 -228.041543 -228.041348 1.945062e-04   1.000 2.46279e-04 8.06686e-04
+        303    21 -228.041543 -228.041351 1.919545e-04   1.000 2.43430e-04 8.05505e-04
+        304    21 -228.041544 -228.041354 1.901174e-04   1.000 2.41015e-04 8.04342e-04
+        305    21 -228.041544 -228.041357 1.872357e-04   1.000 2.38354e-04 8.03194e-04
+        306    21 -228.041544 -228.041360 1.847719e-04   1.000 2.35810e-04 8.02061e-04
+        307    22 -228.041545 -228.041362 1.826824e-04   1.000 2.33494e-04 8.00944e-04
+        308    20 -228.041545 -228.041365 1.801483e-04   1.000 2.31165e-04 7.99841e-04
+        309    22 -228.041546 -228.041367 1.786719e-04   1.000 2.29019e-04 7.98752e-04
+        310    19 -228.041547 -228.041370 1.766894e-04   1.000 2.27009e-04 7.97676e-04
+        311    22 -228.041547 -228.041372 1.755505e-04   1.000 2.24878e-04 7.96614e-04
+        312    20 -228.041548 -228.041374 1.746273e-04   1.000 2.23237e-04 7.95564e-04
+        313    21 -228.041548 -228.041375 1.733395e-04   1.000 2.20995e-04 7.94525e-04
+        314    20 -228.041549 -228.041376 1.731126e-04   1.000 2.19380e-04 7.93499e-04
+        315    21 -228.041550 -228.041377 1.722354e-04   1.000 2.17351e-04 7.92483e-04
+        316    21 -228.041550 -228.041379 1.715604e-04   1.000 2.15476e-04 7.91479e-04
+        317    21 -228.041551 -228.041380 1.712292e-04   1.000 2.13701e-04 7.90486e-04
+        318    21 -228.041551 -228.041381 1.700934e-04   1.000 2.11725e-04 7.89503e-04
+        319    22 -228.041552 -228.041383 1.695507e-04   1.000 2.09859e-04 7.88531e-04
+        320    20 -228.041552 -228.041384 1.682924e-04   1.000 2.07898e-04 7.87570e-04
+        321    21 -228.041553 -228.041386 1.676402e-04   1.000 2.05973e-04 7.86618e-04
+        322    21 -228.041554 -228.041387 1.663985e-04   1.000 2.04139e-04 7.85675e-04
+        323    21 -228.041554 -228.041389 1.654183e-04   1.000 2.02233e-04 7.84741e-04
+        324    21 -228.041554 -228.041391 1.639414e-04   1.000 2.00192e-04 7.83815e-04
+        325    21 -228.041555 -228.041392 1.634318e-04   1.000 1.98465e-04 7.82898e-04
+        326    21 -228.041556 -228.041394 1.620318e-04   1.000 1.96583e-04 7.81987e-04
+        327    22 -228.041556 -228.041395 1.610270e-04   1.000 1.94658e-04 7.81083e-04
+        328    20 -228.041557 -228.041397 1.602242e-04   1.000 1.93047e-04 7.80187e-04
+        329    21 -228.041557 -228.041398 1.591576e-04   1.000 1.91104e-04 7.79296e-04
+        330    20 -228.041558 -228.041399 1.585501e-04   1.000 1.89646e-04 7.78411e-04
+        331    21 -228.041558 -228.041401 1.574565e-04   1.000 1.87720e-04 7.77532e-04
+        332    21 -228.041559 -228.041402 1.570214e-04   1.000 1.86408e-04 7.76036e-04
+        333    22 -228.041560 -228.041410 1.496310e-04   1.000 2.02635e-04 7.70449e-04
+        334    23 -228.041571 -228.041498 7.244691e-05   1.000 2.38885e-04 7.54887e-04
+        335    22 -228.041584 -228.041559 2.588669e-05   1.000 2.84713e-04 7.39837e-04
+        336    23 -228.041597 -228.041564 3.375412e-05   1.000 3.33733e-04 7.26000e-04
+        337    19 -228.041609 -228.041532 7.648752e-05   1.000 3.80565e-04 7.12045e-04
+        338    22 -228.041614 -228.041488 1.262623e-04   1.000 4.21416e-04 6.97667e-04
+        339    22 -228.041620 -228.041457 1.629188e-04   1.000 4.64054e-04 6.83400e-04
+        340    22 -228.041623 -228.041449 1.743681e-04   1.000 5.03498e-04 6.69469e-04
+        341    22 -228.041625 -228.041457 1.683877e-04   1.000 5.37614e-04 6.55775e-04
+        342    22 -228.041624 -228.041472 1.524890e-04   1.000 5.57460e-04 6.42505e-04
+        343    21 -228.041622 -228.041486 1.361711e-04   1.000 5.61179e-04 6.30266e-04
+        344    22 -228.041616 -228.041493 1.228333e-04   1.000 5.46644e-04 6.19539e-04
+        345    19 -228.041609 -228.041498 1.113713e-04   1.000 5.20409e-04 6.10267e-04
+        346    22 -228.041601 -228.041498 1.027395e-04   1.000 4.87193e-04 6.01805e-04
+        347    22 -228.041592 -228.041501 9.124414e-05   1.000 4.52132e-04 5.93370e-04
+        348    22 -228.041585 -228.041504 8.063870e-05   1.000 4.20674e-04 5.84334e-04
+        349    22 -228.041577 -228.041507 6.993863e-05   1.000 3.93187e-04 5.74371e-04
+        350    22 -228.041571 -228.041508 6.277728e-05   1.000 3.72236e-04 5.63430e-04
+        351    22 -228.041565 -228.041505 5.994132e-05   1.000 3.55110e-04 5.51705e-04
+        352    22 -228.041561 -228.041500 6.087728e-05   1.000 3.41807e-04 5.39503e-04
+        353    22 -228.041556 -228.041492 6.358555e-05   1.000 3.29800e-04 5.27166e-04
+        354    22 -228.041551 -228.041486 6.504875e-05   1.000 3.18897e-04 5.14970e-04
+        355    22 -228.041546 -228.041484 6.254495e-05   1.000 3.06818e-04 5.03121e-04
+        356    24 -228.041541 -228.041490 5.067206e-05   1.000 2.97375e-04 4.91901e-04
+        357    24 -228.041539 -228.041497 4.149718e-05   1.000 2.89499e-04 4.81576e-04
+        358    24 -228.041537 -228.041505 3.244218e-05   1.000 2.82105e-04 4.72437e-04
+        359    23 -228.041537 -228.041513 2.378248e-05   1.000 2.74992e-04 4.64754e-04
+        360    22 -228.041540 -228.041521 1.864102e-05   1.000 2.68498e-04 4.58616e-04
+        361    22 -228.041541 -228.041525 1.606340e-05   1.000 2.61913e-04 4.53943e-04
+        362    22 -228.041544 -228.041522 2.167029e-05   1.000 2.54888e-04 4.50521e-04
+        363    22 -228.041546 -228.041517 2.926707e-05   1.000 2.46956e-04 4.48053e-04
+        364    22 -228.041550 -228.041508 4.194817e-05   1.000 2.39477e-04 4.46194e-04
+        365    22 -228.041551 -228.041498 5.270823e-05   1.000 2.31518e-04 4.44631e-04
+        366    22 -228.041555 -228.041488 6.642093e-05   1.000 2.24952e-04 4.43118e-04
+        367    22 -228.041558 -228.041482 7.526739e-05   1.000 2.19416e-04 4.41495e-04
+        368    22 -228.041562 -228.041480 8.264753e-05   1.000 2.16186e-04 4.39678e-04
+        369    22 -228.041566 -228.041480 8.574703e-05   1.000 2.14900e-04 4.37646e-04
+        370    22 -228.041570 -228.041483 8.768443e-05   1.000 2.15986e-04 4.35423e-04
+        371    22 -228.041574 -228.041486 8.839434e-05   1.000 2.19030e-04 4.33070e-04
+        372    22 -228.041578 -228.041490 8.815087e-05   1.000 2.22926e-04 4.30671e-04
+        373    22 -228.041581 -228.041492 8.853140e-05   1.000 2.26955e-04 4.28325e-04
+        374    22 -228.041583 -228.041495 8.822050e-05   1.000 2.29710e-04 4.26127e-04
+        375    22 -228.041584 -228.041496 8.844542e-05   1.000 2.30663e-04 4.24154e-04
+        376    22 -228.041585 -228.041496 8.841152e-05   1.000 2.29327e-04 4.22450e-04
+        377    22 -228.041585 -228.041496 8.871946e-05   1.000 2.25778e-04 4.21021e-04
+        378    22 -228.041584 -228.041495 8.907669e-05   1.000 2.20222e-04 4.19840e-04
+        379    22 -228.041584 -228.041494 8.956569e-05   1.000 2.13055e-04 4.18853e-04
+        380    22 -228.041582 -228.041492 9.012453e-05   1.000 2.04743e-04 4.17990e-04
+        381    21 -228.041581 -228.041491 9.049623e-05   1.000 1.95825e-04 4.17173e-04
+        382    22 -228.041579 -228.041489 9.054400e-05   1.000 1.86292e-04 4.16332e-04
+        383    22 -228.041578 -228.041488 8.998916e-05   1.000 1.77129e-04 4.15405e-04
+        384    22 -228.041576 -228.041487 8.880711e-05   1.000 1.67978e-04 4.14349e-04
+        385    22 -228.041575 -228.041488 8.697970e-05   1.000 1.59629e-04 4.13139e-04
+        386    22 -228.041573 -228.041488 8.452307e-05   1.000 1.51827e-04 4.11769e-04
+        387    22 -228.041571 -228.041490 8.156298e-05   1.000 1.45046e-04 4.10250e-04
+        388    22 -228.041570 -228.041491 7.835243e-05   1.000 1.39125e-04 4.08611e-04
+        389    22 -228.041568 -228.041493 7.496437e-05   1.000 1.34212e-04 4.06886e-04
+        390    22 -228.041567 -228.041495 7.182695e-05   1.000 1.30193e-04 4.05119e-04
+        391    22 -228.041566 -228.041497 6.884767e-05   1.000 1.26946e-04 4.03352e-04
+        392    22 -228.041565 -228.041498 6.641076e-05   1.000 1.24266e-04 4.01620e-04
+        393    22 -228.041564 -228.041500 6.484380e-05   1.000 1.22177e-04 3.99954e-04
+        394    22 -228.041564 -228.041500 6.364736e-05   1.000 1.20253e-04 3.98371e-04
+        395    22 -228.041564 -228.041500 6.375446e-05   1.000 1.18732e-04 3.96876e-04
+        396    22 -228.041564 -228.041500 6.394863e-05   1.000 1.17168e-04 3.95466e-04
+        397    22 -228.041565 -228.041500 6.528078e-05   1.000 1.15863e-04 3.94129e-04
+        398    22 -228.041566 -228.041499 6.681587e-05   1.000 1.14676e-04 3.92844e-04
+        399    22 -228.041567 -228.041498 6.868171e-05   1.000 1.13748e-04 3.91591e-04
+        400    22 -228.041568 -228.041497 7.044843e-05   1.000 1.13003e-04 3.90349e-04
+        401    22 -228.041569 -228.041497 7.239158e-05   1.000 1.12682e-04 3.89099e-04
+        402    22 -228.041570 -228.041496 7.391035e-05   1.000 1.12657e-04 3.87828e-04
+        403    22 -228.041572 -228.041496 7.526953e-05   1.000 1.13054e-04 3.86527e-04
+        404    22 -228.041573 -228.041497 7.622763e-05   1.000 1.13763e-04 3.85195e-04
+        405    22 -228.041574 -228.041497 7.697701e-05   1.000 1.14797e-04 3.83836e-04
+        406    22 -228.041575 -228.041498 7.738451e-05   1.000 1.15988e-04 3.82460e-04
+        407    22 -228.041576 -228.041499 7.766105e-05   1.000 1.17284e-04 3.81077e-04
+        408    22 -228.041577 -228.041500 7.775496e-05   1.000 1.18521e-04 3.79702e-04
+        409    22 -228.041578 -228.041500 7.779594e-05   1.000 1.19609e-04 3.78347e-04
+        410    22 -228.041579 -228.041501 7.777857e-05   1.000 1.20431e-04 3.77023e-04
+        411    22 -228.041579 -228.041501 7.773175e-05   1.000 1.20915e-04 3.75739e-04
+        412    22 -228.041579 -228.041502 7.765931e-05   1.000 1.21010e-04 3.74501e-04
+        413    22 -228.041580 -228.041502 7.753036e-05   1.000 1.20695e-04 3.73309e-04
+        414    22 -228.041579 -228.041502 7.731850e-05   1.000 1.19969e-04 3.72161e-04
+        415    22 -228.041579 -228.041502 7.700423e-05   1.000 1.18864e-04 3.71053e-04
+        416    22 -228.041579 -228.041503 7.654005e-05   1.000 1.17418e-04 3.69976e-04
+        417    22 -228.041579 -228.041503 7.595185e-05   1.000 1.15741e-04 3.68923e-04
+        418    22 -228.041578 -228.041503 7.516675e-05   1.000 1.13842e-04 3.67886e-04
+        419    22 -228.041578 -228.041504 7.426328e-05   1.000 1.11835e-04 3.66856e-04
+        420    22 -228.041577 -228.041504 7.319939e-05   1.000 1.09766e-04 3.65826e-04
+        421    22 -228.041577 -228.041505 7.206315e-05   1.000 1.07720e-04 3.64793e-04
+        422    22 -228.041576 -228.041505 7.087547e-05   1.000 1.05741e-04 3.63754e-04
+        423    22 -228.041576 -228.041506 6.965002e-05   1.000 1.03878e-04 3.62709e-04
+        424    22 -228.041575 -228.041507 6.848116e-05   1.000 1.02166e-04 3.61658e-04
+        425    22 -228.041575 -228.041508 6.738621e-05   1.000 1.00623e-04 3.60604e-04
+        426    22 -228.041575 -228.041508 6.637929e-05   1.000 9.92609e-05 3.59550e-04
+        427    22 -228.041574 -228.041509 6.555807e-05   1.000 9.80876e-05 3.58499e-04
+        428    22 -228.041574 -228.041509 6.484295e-05   1.000 9.70963e-05 3.57455e-04
+        429    22 -228.041574 -228.041510 6.430530e-05   1.000 9.62891e-05 3.56420e-04
+        430    21 -228.041574 -228.041510 6.393416e-05   1.000 9.56778e-05 3.55395e-04
+        431    21 -228.041574 -228.041510 6.368143e-05   1.000 9.52224e-05 3.54381e-04
+        432    22 -228.041574 -228.041511 6.355767e-05   1.000 9.48399e-05 3.53376e-04
+        433    21 -228.041574 -228.041511 6.362463e-05   1.000 9.47499e-05 3.52380e-04
+        434    21 -228.041575 -228.041511 6.370151e-05   1.000 9.47376e-05 3.51391e-04
+        435    22 -228.041575 -228.041511 6.382260e-05   1.000 9.47672e-05 3.50406e-04
+        436    21 -228.041575 -228.041511 6.408074e-05   1.000 9.51200e-05 3.49422e-04
+        437    21 -228.041576 -228.041512 6.420229e-05   1.000 9.54006e-05 3.48438e-04
+        438    22 -228.041576 -228.041512 6.449011e-05   1.000 9.58612e-05 3.47451e-04
+        439    22 -228.041577 -228.041512 6.461817e-05   1.000 9.63963e-05 3.46461e-04
+        440    22 -228.041577 -228.041512 6.479172e-05   1.000 9.69530e-05 3.45466e-04
+        441    22 -228.041578 -228.041513 6.496187e-05   1.000 9.75967e-05 3.44468e-04
+        442    22 -228.041578 -228.041513 6.503132e-05   1.000 9.81982e-05 3.43465e-04
+        443    22 -228.041578 -228.041513 6.508798e-05   1.000 9.87698e-05 3.42459e-04
+        444    22 -228.041579 -228.041514 6.510079e-05   1.000 9.92913e-05 3.41451e-04
+        445    22 -228.041579 -228.041514 6.509915e-05   1.000 9.96943e-05 3.40442e-04
+        446    22 -228.041579 -228.041514 6.505089e-05   1.000 1.00052e-04 3.39433e-04
+        447    22 -228.041579 -228.041514 6.496706e-05   1.000 1.00239e-04 3.38424e-04
+        448    22 -228.041580 -228.041515 6.482992e-05   1.000 1.00330e-04 3.37415e-04
+        449    22 -228.041580 -228.041515 6.464186e-05   1.000 1.00247e-04 3.36408e-04
+        450    22 -228.041580 -228.041515 6.443635e-05   1.000 1.00070e-04 3.35402e-04
+        451    22 -228.041580 -228.041516 6.416084e-05   1.000 9.97570e-05 3.34395e-04
+        452    22 -228.041580 -228.041516 6.384554e-05   1.000 9.93497e-05 3.33388e-04
+        453    22 -228.041580 -228.041516 6.348343e-05   1.000 9.88022e-05 3.32379e-04
+        454    22 -228.041580 -228.041517 6.311341e-05   1.000 9.82002e-05 3.31368e-04
+        455    22 -228.041580 -228.041517 6.269366e-05   1.000 9.75107e-05 3.30354e-04
+        456    22 -228.041580 -228.041517 6.226835e-05   1.000 9.67985e-05 3.29337e-04
+        457    22 -228.041579 -228.041518 6.179791e-05   1.000 9.60333e-05 3.28316e-04
+        458    22 -228.041579 -228.041518 6.137994e-05   1.000 9.52693e-05 3.27291e-04
+        459    22 -228.041579 -228.041518 6.091805e-05   1.000 9.45137e-05 3.26262e-04
+        460    22 -228.041579 -228.041519 6.048850e-05   1.000 9.37608e-05 3.25230e-04
+        461    22 -228.041579 -228.041519 6.008541e-05   1.000 9.30562e-05 3.24195e-04
+        462    22 -228.041579 -228.041519 5.969654e-05   1.000 9.23956e-05 3.23157e-04
+        463    22 -228.041579 -228.041520 5.937333e-05   1.000 9.17922e-05 3.22118e-04
+        464    21 -228.041579 -228.041520 5.917707e-05   1.000 9.13866e-05 3.21077e-04
+        465    22 -228.041579 -228.041520 5.866296e-05   1.000 9.06909e-05 3.20036e-04
+        466    22 -228.041579 -228.041520 5.865921e-05   1.000 9.03840e-05 3.18994e-04
+        467    22 -228.041579 -228.041521 5.836761e-05   1.000 8.99247e-05 3.17953e-04
+        468    22 -228.041579 -228.041521 5.826628e-05   1.000 8.96856e-05 3.16912e-04
+        469    22 -228.041579 -228.041521 5.806665e-05   1.000 8.93819e-05 3.15871e-04
+        470    22 -228.041579 -228.041521 5.802377e-05   1.000 8.92350e-05 3.14830e-04
+        471    22 -228.041580 -228.041522 5.789340e-05   1.000 8.90736e-05 3.13790e-04
+        472    22 -228.041580 -228.041522 5.787889e-05   1.000 8.90238e-05 3.12750e-04
+        473    22 -228.041580 -228.041522 5.777110e-05   1.000 8.89207e-05 3.11710e-04
+        474    22 -228.041580 -228.041522 5.776247e-05   1.000 8.89268e-05 3.10669e-04
+        475    22 -228.041580 -228.041522 5.770213e-05   1.000 8.89044e-05 3.09628e-04
+        476    22 -228.041580 -228.041523 5.767629e-05   1.000 8.89372e-05 3.08586e-04
+        477    22 -228.041581 -228.041523 5.761170e-05   1.000 8.89364e-05 3.07544e-04
+        478    22 -228.041581 -228.041523 5.756389e-05   1.000 8.89578e-05 3.06501e-04
+        479    22 -228.041581 -228.041523 5.751578e-05   1.000 8.89585e-05 3.05458e-04
+        480    22 -228.041581 -228.041524 5.741271e-05   1.000 8.89499e-05 3.04414e-04
+        481    22 -228.041581 -228.041524 5.734059e-05   1.000 8.89043e-05 3.03370e-04
+        482    22 -228.041581 -228.041524 5.721034e-05   1.000 8.88223e-05 3.02326e-04
+        483    22 -228.041581 -228.041524 5.712468e-05   1.000 8.87354e-05 3.01281e-04
+        484    22 -228.041582 -228.041525 5.695627e-05   1.000 8.86020e-05 3.00236e-04
+        485    22 -228.041582 -228.041525 5.680442e-05   1.000 8.83972e-05 2.99191e-04
+        486    22 -228.041582 -228.041525 5.662028e-05   1.000 8.81890e-05 2.98145e-04
+        487    22 -228.041582 -228.041525 5.645320e-05   1.000 8.79278e-05 2.97099e-04
+        488    22 -228.041582 -228.041526 5.623079e-05   1.000 8.76204e-05 2.96053e-04
+        489    22 -228.041582 -228.041526 5.602678e-05   1.000 8.73173e-05 2.95006e-04
+        490    22 -228.041582 -228.041526 5.580042e-05   1.000 8.69615e-05 2.93959e-04
+        491    22 -228.041582 -228.041526 5.557192e-05   1.000 8.66069e-05 2.92911e-04
+        492    22 -228.041582 -228.041527 5.530150e-05   1.000 8.61881e-05 2.91863e-04
+        493    22 -228.041582 -228.041527 5.509335e-05   1.000 8.58120e-05 2.90814e-04
+        494    22 -228.041582 -228.041527 5.482128e-05   1.000 8.53936e-05 2.89765e-04
+        495    22 -228.041582 -228.041527 5.459716e-05   1.000 8.50005e-05 2.88714e-04
+        496    22 -228.041582 -228.041528 5.432585e-05   1.000 8.45820e-05 2.87664e-04
+        497    21 -228.041582 -228.041528 5.416828e-05   1.000 8.42673e-05 2.86613e-04
+        498    22 -228.041582 -228.041528 5.381282e-05   1.000 8.38098e-05 2.85562e-04
+        499    22 -228.041582 -228.041528 5.367249e-05   1.000 8.34679e-05 2.84511e-04
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization did not converge in  20 iterations 
+            Total energy change: -1.110955e-04
+            Final gradient norm: 1.500152e-04
+
+        500    22 -228.041693 -227.899121 1.425723e-01   0.293 8.31045e-05 2.83459e-04
+        501    32 -228.042056 -228.045994 3.937847e-03   0.293 6.59141e-02 1.25023e-02
+        502    20 -228.040527 -228.044383 3.856347e-03   0.293 2.74202e-02 8.32755e-03
+        503    22 -228.041137 -228.043052 1.915443e-03   0.293 2.32624e-02 4.81894e-03
+        504    23 -228.040803 -228.040303 5.001706e-04   0.293 1.67293e-02 4.33756e-03
+        505    22 -228.042381 -228.041539 8.424183e-04   0.293 1.23944e-02 4.13894e-03
+        506    21 -228.042630 -228.039413 3.216656e-03   0.293 1.16753e-02 4.18036e-03
+        507    21 -228.042812 -228.039593 3.218053e-03   0.293 1.26152e-02 3.58668e-03
+        508    19 -228.042018 -228.039856 2.162189e-03   0.293 9.53362e-03 2.74532e-03
+        509    21 -228.041686 -228.040932 7.543685e-04   0.293 8.13065e-03 2.08116e-03
+        510    22 -228.041449 -228.041390 5.866887e-05   0.293 6.76692e-03 1.79889e-03
+        511    22 -228.041440 -228.041743 3.024309e-04   0.293 5.49809e-03 1.83979e-03
+        512    22 -228.041550 -228.042208 6.582731e-04   0.293 4.42874e-03 1.88126e-03
+        513    21 -228.041726 -228.042600 8.745052e-04   0.293 4.04256e-03 1.78350e-03
+        514    22 -228.041913 -228.042736 8.228447e-04   0.293 4.31656e-03 1.58270e-03
+        515    22 -228.042100 -228.042564 4.642183e-04   0.293 4.78021e-03 1.34635e-03
+        516    24 -228.042226 -228.042130 9.616267e-05   0.293 5.09406e-03 1.11943e-03
+        517    24 -228.042345 -228.041600 7.451017e-04   0.293 5.18079e-03 9.43945e-04
+        518    23 -228.042374 -228.041138 1.236542e-03   0.293 5.00718e-03 8.58846e-04
+        519    23 -228.042314 -228.040876 1.438569e-03   0.293 4.46001e-03 8.62540e-04
+        520    24 -228.042192 -228.040916 1.276301e-03   0.293 3.92366e-03 8.91057e-04
+        521    22 -228.042086 -228.041142 9.442847e-04   0.293 3.57577e-03 8.74729e-04
+        522    24 -228.041984 -228.041477 5.062752e-04   0.293 3.47982e-03 7.78751e-04
+        523    22 -228.041930 -228.041821 1.094299e-04   0.293 3.54616e-03 6.18007e-04
+        524    23 -228.041888 -228.042083 1.947120e-04   0.293 3.59225e-03 4.58790e-04
+        525    23 -228.041880 -228.042217 3.366722e-04   0.293 3.52009e-03 4.09533e-04
+        526    24 -228.041873 -228.042224 3.512583e-04   0.293 3.32037e-03 4.82802e-04
+        527    23 -228.041859 -228.042135 2.760177e-04   0.293 3.06234e-03 5.64946e-04
+        528    22 -228.041848 -228.041989 1.409014e-04   0.293 2.82688e-03 5.88990e-04
+        529    23 -228.041816 -228.041826 1.010772e-05   0.293 2.64640e-03 5.48125e-04
+        530    22 -228.041805 -228.041674 1.306136e-04   0.293 2.49936e-03 4.72269e-04
+        531    24 -228.041779 -228.041557 2.216934e-04   0.293 2.31698e-03 4.13293e-04
+        532    23 -228.041769 -228.041483 2.856672e-04   0.293 2.08561e-03 4.10329e-04
+        533    24 -228.041762 -228.041457 3.054409e-04   0.293 1.82983e-03 4.46107e-04
+        534    24 -228.041767 -228.041474 2.926101e-04   0.293 1.62324e-03 4.76974e-04
+        535    23 -228.041782 -228.041524 2.575636e-04   0.293 1.52367e-03 4.79752e-04
+        536    23 -228.041794 -228.041593 2.012538e-04   0.293 1.51576e-03 4.56451e-04
+        537    24 -228.041810 -228.041664 1.450608e-04   0.293 1.53542e-03 4.24623e-04
+        538    22 -228.041822 -228.041728 9.433523e-05   0.293 1.52547e-03 4.04269e-04
+        539    22 -228.041836 -228.041775 6.067383e-05   0.293 1.47092e-03 4.02881e-04
+        540    22 -228.041839 -228.041804 3.496801e-05   0.293 1.38949e-03 4.11317e-04
+        541    21 -228.041840 -228.041815 2.503837e-05   0.293 1.31630e-03 4.15674e-04
+        542    22 -228.041833 -228.041811 2.167218e-05   0.293 1.26029e-03 4.08761e-04
+        543    21 -228.041831 -228.041802 2.956802e-05   0.293 1.23231e-03 3.92308e-04
+        544    22 -228.041825 -228.041787 3.731771e-05   0.293 1.19715e-03 3.73530e-04
+        545    21 -228.041827 -228.041775 5.134137e-05   0.293 1.15489e-03 3.59465e-04
+        546    22 -228.041826 -228.041764 6.197043e-05   0.293 1.09007e-03 3.52072e-04
+        547    22 -228.041834 -228.041756 7.802693e-05   0.293 1.03178e-03 3.47665e-04
+        548    22 -228.041841 -228.041750 9.105455e-05   0.293 9.86048e-04 3.40861e-04
+        549    21 -228.041853 -228.041746 1.069972e-04   0.293 9.69324e-04 3.28674e-04
+        550    22 -228.041862 -228.041744 1.185787e-04   0.293 9.64898e-04 3.11929e-04
+        551    21 -228.041874 -228.041742 1.318245e-04   0.293 9.66533e-04 2.94110e-04
+        552    22 -228.041881 -228.041742 1.390376e-04   0.293 9.53839e-04 2.78797e-04
+        553    22 -228.041887 -228.041743 1.440400e-04   0.293 9.33304e-04 2.67226e-04
+        554    22 -228.041891 -228.041746 1.446126e-04   0.293 9.06947e-04 2.57767e-04
+        555    22 -228.041892 -228.041752 1.406110e-04   0.293 8.86869e-04 2.47642e-04
+        556    22 -228.041892 -228.041759 1.335311e-04   0.293 8.76029e-04 2.35150e-04
+        557    23 -228.041892 -228.041767 1.253518e-04   0.293 8.71726e-04 2.20637e-04
+        558    23 -228.041889 -228.041776 1.130450e-04   0.293 8.70228e-04 2.06002e-04
+        559    22 -228.041888 -228.041783 1.044122e-04   0.293 8.64578e-04 1.93207e-04
+        560    23 -228.041885 -228.041790 9.557044e-05   0.293 8.55837e-04 1.82859e-04
+        561    22 -228.041884 -228.041793 9.046409e-05   0.293 8.45920e-04 1.73930e-04
+        562    23 -228.041882 -228.041794 8.793185e-05   0.293 8.37940e-04 1.64757e-04
+        563    22 -228.041880 -228.041791 8.911937e-05   0.293 8.32423e-04 1.54341e-04
+        564    23 -228.041879 -228.041787 9.252364e-05   0.293 8.27428e-04 1.42919e-04
+        565    22 -228.041879 -228.041781 9.772161e-05   0.293 8.20552e-04 1.31627e-04
+        566    23 -228.041877 -228.041774 1.022084e-04   0.293 8.10229e-04 1.21601e-04
+        567    22 -228.041876 -228.041769 1.073413e-04   0.293 7.97507e-04 1.13148e-04
+        568    22 -228.041874 -228.041764 1.102334e-04   0.293 7.84212e-04 1.05606e-04
+        569    23 -228.041873 -228.041761 1.117798e-04   0.293 7.72433e-04 9.79684e-05
+        570    22 -228.041871 -228.041760 1.114144e-04   0.293 7.63002e-04 8.96687e-05
+        571    23 -228.041870 -228.041760 1.098138e-04   0.293 7.55379e-04 8.09198e-05
+        572    22 -228.041869 -228.041762 1.070633e-04   0.293 7.48764e-04 7.24950e-05
+        573    23 -228.041868 -228.041764 1.038022e-04   0.293 7.42394e-04 6.51572e-05
+        574    22 -228.041868 -228.041767 1.017591e-04   0.293 7.36603e-04 5.91029e-05
+        575    23 -228.041867 -228.041769 9.863499e-05   0.293 7.31466e-04 5.38530e-05
+        576    24 -228.041867 -228.041770 9.731590e-05   0.293 7.27592e-04 4.86904e-05
+        577    24 -228.041867 -228.041770 9.696432e-05   0.293 7.24537e-04 4.32206e-05
+        578    26 -228.041867 -228.041770 9.651825e-05   0.293 7.21783e-04 3.76304e-05
+        579    25 -228.041867 -228.041769 9.744838e-05   0.293 7.18619e-04 3.25554e-05
+        580    27 -228.041866 -228.041768 9.817648e-05   0.293 7.14767e-04 2.86653e-05
+        581    25 -228.041866 -228.041766 9.958391e-05   0.293 7.10194e-04 2.61483e-05
+        582    28 -228.041865 -228.041765 1.003858e-04   0.293 7.05491e-04 2.45827e-05
+        583    28 -228.041865 -228.041763 1.017850e-04   0.293 7.00583e-04 2.33655e-05
+        584    28 -228.041864 -228.041762 1.026445e-04   0.293 6.95993e-04 2.22620e-05
+        585    28 -228.041864 -228.041761 1.035051e-04   0.293 6.91686e-04 2.15063e-05
+        586    28 -228.041864 -228.041760 1.042208e-04   0.293 6.87744e-04 2.14996e-05
+        587    28 -228.041864 -228.041759 1.048482e-04   0.293 6.84145e-04 2.23691e-05
+        588    28 -228.041864 -228.041759 1.054322e-04   0.293 6.81022e-04 2.38256e-05
+        589    28 -228.041865 -228.041759 1.059020e-04   0.293 6.78430e-04 2.54296e-05
+        590    28 -228.041865 -228.041758 1.062057e-04   0.293 6.76324e-04 2.68871e-05
+        591    28 -228.041865 -228.041758 1.064451e-04   0.293 6.74622e-04 2.81352e-05
+        592    28 -228.041865 -228.041758 1.064998e-04   0.293 6.73079e-04 2.92616e-05
+        593    28 -228.041865 -228.041758 1.063908e-04   0.293 6.71527e-04 3.03716e-05
+        594    28 -228.041864 -228.041758 1.062038e-04   0.293 6.69867e-04 3.14924e-05
+        595    28 -228.041864 -228.041758 1.058805e-04   0.293 6.68064e-04 3.25648e-05
+        596    28 -228.041863 -228.041758 1.054861e-04   0.293 6.66149e-04 3.34988e-05
+        597    21 -228.041864 -228.041758 1.054844e-04   0.293 6.64054e-04 3.42354e-05
+        598    23 -228.041863 -228.041758 1.046541e-04   0.293 6.62525e-04 3.47784e-05
+        599    23 -228.041863 -228.041758 1.048411e-04   0.293 6.60840e-04 3.51687e-05
+        600    23 -228.041862 -228.041757 1.046500e-04   0.293 6.59299e-04 3.54503e-05
+        601    23 -228.041861 -228.041756 1.048841e-04   0.293 6.57769e-04 3.56435e-05
+        602    23 -228.041861 -228.041756 1.050304e-04   0.293 6.56429e-04 3.57391e-05
+        603    23 -228.041860 -228.041755 1.050750e-04   0.293 6.55183e-04 3.57152e-05
+        604    23 -228.041860 -228.041755 1.051966e-04   0.293 6.54055e-04 3.55596e-05
+        605    23 -228.041859 -228.041754 1.051396e-04   0.293 6.52956e-04 3.52798e-05
+        606    28 -228.041858 -228.041753 1.047114e-04   0.293 6.52121e-04 3.49027e-05
+        607    21 -228.041859 -228.041754 1.053404e-04   0.293 6.50255e-04 3.44409e-05
+        608    28 -228.041857 -228.041753 1.036752e-04   0.293 6.49705e-04 3.39190e-05
+        609    28 -228.041857 -228.041753 1.041304e-04   0.293 6.47940e-04 3.33276e-05
+        610    28 -228.041856 -228.041753 1.030204e-04   0.293 6.46695e-04 3.26696e-05
+        611    28 -228.041856 -228.041753 1.026779e-04   0.293 6.45226e-04 3.19453e-05
+        612    28 -228.041855 -228.041753 1.017440e-04   0.293 6.43975e-04 3.11621e-05
+        613    28 -228.041855 -228.041754 1.012597e-04   0.293 6.42713e-04 3.03336e-05
+        614    28 -228.041854 -228.041754 1.005996e-04   0.293 6.41553e-04 2.94735e-05
+        615    28 -228.041854 -228.041754 1.001084e-04   0.293 6.40410e-04 2.85915e-05
+        616    28 -228.041853 -228.041754 9.959661e-05   0.293 6.39327e-04 2.76918e-05
+        617    28 -228.041853 -228.041754 9.921166e-05   0.293 6.38262e-04 2.67768e-05
+        618    28 -228.041852 -228.041754 9.876884e-05   0.293 6.37162e-04 2.58506e-05
+        619    28 -228.041852 -228.041754 9.839319e-05   0.293 6.36008e-04 2.49208e-05
+        620    28 -228.041851 -228.041753 9.795612e-05   0.293 6.34744e-04 2.39978e-05
+        621    28 -228.041851 -228.041753 9.761774e-05   0.293 6.33404e-04 2.30914e-05
+        622    28 -228.041851 -228.041753 9.720068e-05   0.293 6.31929e-04 2.22093e-05
+        623    28 -228.041850 -228.041753 9.677834e-05   0.293 6.30337e-04 2.13562e-05
+        624    28 -228.041850 -228.041753 9.632553e-05   0.293 6.28636e-04 2.05357e-05
+        625    28 -228.041849 -228.041753 9.586266e-05   0.293 6.26844e-04 1.97520e-05
+        626    28 -228.041849 -228.041753 9.540238e-05   0.293 6.24983e-04 1.90107e-05
+        627    28 -228.041848 -228.041753 9.493306e-05   0.293 6.23062e-04 1.83183e-05
+        628    28 -228.041848 -228.041754 9.445452e-05   0.293 6.21093e-04 1.76804e-05
+        629    28 -228.041848 -228.041754 9.396999e-05   0.293 6.19083e-04 1.71007e-05
+        630    28 -228.041847 -228.041754 9.350073e-05   0.293 6.17043e-04 1.65812e-05
+        631    28 -228.041847 -228.041754 9.300987e-05   0.293 6.14957e-04 1.61224e-05
+        632    28 -228.041846 -228.041754 9.258554e-05   0.293 6.12856e-04 1.57244e-05
+        633    28 -228.041846 -228.041754 9.207161e-05   0.293 6.10675e-04 1.53872e-05
+        634    28 -228.041846 -228.041754 9.161644e-05   0.293 6.08463e-04 1.51100e-05
+        635    28 -228.041845 -228.041754 9.111753e-05   0.293 6.06177e-04 1.48907e-05
+        636    28 -228.041845 -228.041754 9.067444e-05   0.293 6.03858e-04 1.47254e-05
+        637    28 -228.041844 -228.041754 9.020465e-05   0.293 6.01480e-04 1.46091e-05
+        638    28 -228.041844 -228.041754 8.974227e-05   0.293 5.99061e-04 1.45361e-05
+        639    28 -228.041844 -228.041754 8.930100e-05   0.293 5.96614e-04 1.45003e-05
+        640    28 -228.041843 -228.041754 8.889565e-05   0.293 5.94159e-04 1.44962e-05
+        641    28 -228.041843 -228.041754 8.844561e-05   0.293 5.91671e-04 1.45183e-05
+        642    28 -228.041843 -228.041755 8.803331e-05   0.293 5.89186e-04 1.45611e-05
+        643    28 -228.041842 -228.041755 8.763033e-05   0.293 5.86702e-04 1.46194e-05
+        644    28 -228.041842 -228.041755 8.724063e-05   0.293 5.84223e-04 1.46880e-05
+        645    28 -228.041842 -228.041755 8.686114e-05   0.293 5.81752e-04 1.47623e-05
+        646    28 -228.041841 -228.041755 8.644916e-05   0.293 5.79272e-04 1.48382e-05
+        647    28 -228.041841 -228.041755 8.607346e-05   0.293 5.76807e-04 1.49125e-05
+        648    28 -228.041841 -228.041755 8.569643e-05   0.293 5.74347e-04 1.49820e-05
+        649    28 -228.041840 -228.041755 8.535316e-05   0.293 5.71908e-04 1.50444e-05
+        650    28 -228.041840 -228.041755 8.495160e-05   0.293 5.69456e-04 1.50975e-05
+        651    28 -228.041840 -228.041755 8.464266e-05   0.293 5.67050e-04 1.51392e-05
+        652    28 -228.041839 -228.041755 8.423264e-05   0.293 5.64624e-04 1.51683e-05
+        653    28 -228.041839 -228.041755 8.393857e-05   0.293 5.62257e-04 1.51834e-05
+        654    27 -228.041839 -228.041755 8.360022e-05   0.293 5.59901e-04 1.51839e-05
+        655    27 -228.041839 -228.041755 8.325843e-05   0.293 5.57567e-04 1.51692e-05
+        656    28 -228.041838 -228.041755 8.295095e-05   0.293 5.55272e-04 1.51390e-05
+        657    28 -228.041838 -228.041755 8.263427e-05   0.293 5.53003e-04 1.50932e-05
+        658    28 -228.041838 -228.041755 8.238802e-05   0.293 5.50792e-04 1.50319e-05
+        659    28 -228.041837 -228.041755 8.206202e-05   0.293 5.48581e-04 1.49551e-05
+        660    28 -228.041837 -228.041755 8.180190e-05   0.293 5.46420e-04 1.48633e-05
+        661    28 -228.041837 -228.041755 8.150559e-05   0.293 5.44274e-04 1.47569e-05
+        662    28 -228.041837 -228.041755 8.127015e-05   0.293 5.42177e-04 1.46365e-05
+        663    28 -228.041837 -228.041755 8.104735e-05   0.293 5.40118e-04 1.45027e-05
+        664    28 -228.041836 -228.041755 8.070425e-05   0.293 5.38038e-04 1.43561e-05
+        665    28 -228.041836 -228.041755 8.056632e-05   0.293 5.36060e-04 1.41974e-05
+        666    28 -228.041836 -228.041755 8.023656e-05   0.293 5.34047e-04 1.40275e-05
+        667    28 -228.041836 -228.041755 8.005623e-05   0.293 5.32110e-04 1.38471e-05
+        668    28 -228.041835 -228.041755 7.979625e-05   0.293 5.30180e-04 1.36570e-05
+        669    28 -228.041835 -228.041755 7.957722e-05   0.293 5.28291e-04 1.34580e-05
+        670    28 -228.041835 -228.041755 7.936681e-05   0.293 5.26439e-04 1.32510e-05
+        671    28 -228.041835 -228.041755 7.920314e-05   0.293 5.24637e-04 1.30368e-05
+        672    28 -228.041834 -228.041755 7.894232e-05   0.293 5.22830e-04 1.28164e-05
+        673    28 -228.041834 -228.041755 7.878057e-05   0.293 5.21085e-04 1.25904e-05
+        674    28 -228.041834 -228.041755 7.855939e-05   0.293 5.19350e-04 1.23597e-05
+        675    28 -228.041834 -228.041755 7.837759e-05   0.293 5.17651e-04 1.21252e-05
+        676    28 -228.041834 -228.041755 7.818989e-05   0.293 5.15979e-04 1.18876e-05
+        677    28 -228.041833 -228.041755 7.798502e-05   0.293 5.14323e-04 1.16478e-05
+        678    28 -228.041833 -228.041755 7.788545e-05   0.293 5.12734e-04 1.14064e-05
+        679    28 -228.041833 -228.041755 7.765679e-05   0.293 5.11126e-04 1.11642e-05
+        680    28 -228.041833 -228.041755 7.748736e-05   0.293 5.09559e-04 1.09218e-05
+        681    28 -228.041832 -228.041755 7.732947e-05   0.293 5.08022e-04 1.06799e-05
+        682    28 -228.041832 -228.041755 7.716021e-05   0.293 5.06505e-04 1.04392e-05
+        683    28 -228.041832 -228.041755 7.698250e-05   0.293 5.05006e-04 1.02002e-05
+        684    30 -228.041832 -228.041755 7.682186e-05   0.293 5.03535e-04 9.96321e-06
+        685    27 -228.041832 -228.041755 7.673801e-05   0.293 5.02126e-04 9.72956e-06
+        686    28 -228.041831 -228.041755 7.649888e-05   0.293 5.00671e-04 9.49872e-06
+        687    28 -228.041831 -228.041755 7.640015e-05   0.293 4.99286e-04 9.27161e-06
+        688    28 -228.041831 -228.041755 7.624464e-05   0.293 4.97911e-04 9.04868e-06
+        689    28 -228.041831 -228.041755 7.608591e-05   0.293 4.96546e-04 8.83023e-06
+        690    28 -228.041831 -228.041755 7.597224e-05   0.293 4.95222e-04 8.61662e-06
+        691    28 -228.041831 -228.041755 7.584575e-05   0.293 4.93912e-04 8.40814e-06
+        692    28 -228.041830 -228.041755 7.567138e-05   0.293 4.92602e-04 8.20508e-06
+        693    28 -228.041830 -228.041755 7.558330e-05   0.293 4.91338e-04 8.00764e-06
+        694    28 -228.041830 -228.041755 7.538636e-05   0.293 4.90053e-04 7.81603e-06
+        695    28 -228.041830 -228.041754 7.530689e-05   0.293 4.88824e-04 7.63038e-06
+        696    28 -228.041830 -228.041754 7.514262e-05   0.293 4.87583e-04 7.45085e-06
+        697    30 -228.041829 -228.041754 7.498847e-05   0.293 4.86354e-04 7.27734e-06
+        698    29 -228.041829 -228.041754 7.485206e-05   0.293 4.85152e-04 7.11021e-06
+        699    30 -228.041829 -228.041754 7.474917e-05   0.293 4.83970e-04 6.94941e-06
+        700    30 -228.041829 -228.041754 7.466544e-05   0.293 4.82816e-04 6.79485e-06
+        701    30 -228.041829 -228.041754 7.444946e-05   0.293 4.81625e-04 6.64656e-06
+        702    30 -228.041828 -228.041754 7.435773e-05   0.293 4.80485e-04 6.50443e-06
+        703    31 -228.041828 -228.041754 7.425034e-05   0.293 4.79353e-04 6.36853e-06
+        704    30 -228.041828 -228.041754 7.410093e-05   0.293 4.78228e-04 6.23850e-06
+        705    30 -228.041828 -228.041754 7.403635e-05   0.293 4.77135e-04 6.11443e-06
+        706    30 -228.041828 -228.041754 7.382641e-05   0.293 4.76005e-04 5.99632e-06
+        707    30 -228.041828 -228.041754 7.377228e-05   0.293 4.74935e-04 5.88383e-06
+        708    30 -228.041827 -228.041754 7.359840e-05   0.293 4.73837e-04 5.77687e-06
+        709    30 -228.041827 -228.041754 7.348482e-05   0.293 4.72766e-04 5.67522e-06
+        710    30 -228.041827 -228.041754 7.340904e-05   0.293 4.71725e-04 5.57872e-06
+        711    31 -228.041827 -228.041754 7.323122e-05   0.293 4.70650e-04 5.48725e-06
+        712    30 -228.041827 -228.041754 7.314598e-05   0.293 4.69624e-04 5.40036e-06
+        713    30 -228.041827 -228.041754 7.300016e-05   0.293 4.68581e-04 5.31806e-06
+        714    31 -228.041826 -228.041753 7.289863e-05   0.293 4.67553e-04 5.24040e-06
+        715    31 -228.041826 -228.041753 7.276881e-05   0.293 4.66530e-04 5.16679e-06
+        716    31 -228.041826 -228.041753 7.265467e-05   0.293 4.65515e-04 5.09718e-06
+        717    31 -228.041826 -228.041753 7.253148e-05   0.293 4.64506e-04 5.03147e-06
+        718    31 -228.041826 -228.041753 7.241061e-05   0.293 4.63503e-04 4.96944e-06
+        719    31 -228.041825 -228.041753 7.228754e-05   0.293 4.62506e-04 4.91090e-06
+        720    31 -228.041825 -228.041753 7.216650e-05   0.293 4.61515e-04 4.85569e-06
+        721    31 -228.041825 -228.041753 7.205486e-05   0.293 4.60534e-04 4.80364e-06
+        722    31 -228.041825 -228.041753 7.191582e-05   0.293 4.59549e-04 4.75461e-06
+        723    31 -228.041825 -228.041753 7.180273e-05   0.293 4.58578e-04 4.70844e-06
+        724    31 -228.041825 -228.041753 7.167839e-05   0.293 4.57609e-04 4.66499e-06
+        725    31 -228.041824 -228.041753 7.155848e-05   0.293 4.56645e-04 4.62413e-06
+        726    31 -228.041824 -228.041753 7.143705e-05   0.293 4.55686e-04 4.58572e-06
+        727    31 -228.041824 -228.041753 7.131713e-05   0.293 4.54732e-04 4.54965e-06
+        728    31 -228.041824 -228.041753 7.119604e-05   0.293 4.53781e-04 4.51579e-06
+        729    31 -228.041824 -228.041753 7.107649e-05   0.293 4.52835e-04 4.48404e-06
+        730    31 -228.041824 -228.041753 7.095398e-05   0.293 4.51891e-04 4.45429e-06
+        731    31 -228.041823 -228.041753 7.083672e-05   0.293 4.50954e-04 4.42643e-06
+        732    31 -228.041823 -228.041753 7.071428e-05   0.293 4.50018e-04 4.40037e-06
+        733    31 -228.041823 -228.041753 7.059409e-05   0.293 4.49086e-04 4.37601e-06
+        734    31 -228.041823 -228.041753 7.047389e-05   0.293 4.48158e-04 4.35326e-06
+        735    31 -228.041823 -228.041752 7.035478e-05   0.293 4.47234e-04 4.33203e-06
+        736    31 -228.041823 -228.041752 7.023448e-05   0.293 4.46312e-04 4.31224e-06
+        737    31 -228.041823 -228.041752 7.011336e-05   0.293 4.45394e-04 4.29380e-06
+        738    31 -228.041822 -228.041752 6.999512e-05   0.293 4.44479e-04 4.27662e-06
+        739    30 -228.041822 -228.041752 6.988386e-05   0.293 4.43572e-04 4.26062e-06
+        740    30 -228.041822 -228.041752 6.972207e-05   0.293 4.42647e-04 4.24575e-06
+        741    31 -228.041822 -228.041752 6.965869e-05   0.293 4.41761e-04 4.23189e-06
+        742    31 -228.041822 -228.041752 6.950638e-05   0.293 4.40849e-04 4.21898e-06
+        743    31 -228.041822 -228.041752 6.940744e-05   0.293 4.39957e-04 4.20694e-06
+        744    31 -228.041821 -228.041752 6.927824e-05   0.293 4.39059e-04 4.19570e-06
+        745    31 -228.041821 -228.041752 6.916677e-05   0.293 4.38169e-04 4.18518e-06
+        746    31 -228.041821 -228.041752 6.904604e-05   0.293 4.37279e-04 4.17533e-06
+        747    31 -228.041821 -228.041752 6.892957e-05   0.293 4.36393e-04 4.16606e-06
+        748    31 -228.041821 -228.041752 6.881403e-05   0.293 4.35511e-04 4.15733e-06
+        749    31 -228.041821 -228.041752 6.869810e-05   0.293 4.34631e-04 4.14905e-06
+        750    31 -228.041821 -228.041752 6.858149e-05   0.293 4.33755e-04 4.14117e-06
+        751    31 -228.041820 -228.041752 6.847350e-05   0.293 4.32884e-04 4.13361e-06
+        752    31 -228.041820 -228.041752 6.834615e-05   0.293 4.32010e-04 4.12632e-06
+        753    31 -228.041820 -228.041752 6.823947e-05   0.293 4.31146e-04 4.11925e-06
+        754    31 -228.041820 -228.041752 6.812154e-05   0.293 4.30281e-04 4.11233e-06
+        755    31 -228.041820 -228.041752 6.800995e-05   0.293 4.29421e-04 4.10552e-06
+        756    31 -228.041820 -228.041752 6.789641e-05   0.293 4.28564e-04 4.09876e-06
+        757    31 -228.041820 -228.041752 6.778440e-05   0.293 4.27711e-04 4.09201e-06
+        758    31 -228.041819 -228.041752 6.765894e-05   0.293 4.26855e-04 4.08523e-06
+        759    31 -228.041819 -228.041752 6.756912e-05   0.293 4.26016e-04 4.07836e-06
+        760    31 -228.041819 -228.041752 6.744361e-05   0.293 4.25169e-04 4.07137e-06
+        761    31 -228.041819 -228.041752 6.734302e-05   0.293 4.24332e-04 4.06423e-06
+        762    31 -228.041819 -228.041752 6.722561e-05   0.293 4.23494e-04 4.05690e-06
+        763    31 -228.041819 -228.041752 6.712099e-05   0.293 4.22663e-04 4.04934e-06
+        764    31 -228.041819 -228.041752 6.700944e-05   0.293 4.21833e-04 4.04154e-06
+        765    31 -228.041818 -228.041751 6.690361e-05   0.293 4.21009e-04 4.03346e-06
+        766    31 -228.041818 -228.041751 6.678661e-05   0.293 4.20183e-04 4.02509e-06
+        767    31 -228.041818 -228.041751 6.669300e-05   0.293 4.19370e-04 4.01641e-06
+        768    31 -228.041818 -228.041751 6.657894e-05   0.293 4.18553e-04 4.00740e-06
+        769    31 -228.041818 -228.041751 6.647800e-05   0.293 4.17744e-04 3.99803e-06
+        770    31 -228.041818 -228.041751 6.636830e-05   0.293 4.16936e-04 3.98831e-06
+        771    31 -228.041818 -228.041751 6.626719e-05   0.293 4.16134e-04 3.97821e-06
+        772    31 -228.041817 -228.041751 6.616047e-05   0.293 4.15334e-04 3.96774e-06
+        773    31 -228.041817 -228.041751 6.605856e-05   0.293 4.14538e-04 3.95689e-06
+        774    31 -228.041817 -228.041751 6.595452e-05   0.293 4.13746e-04 3.94565e-06
+        775    31 -228.041817 -228.041751 6.585257e-05   0.293 4.12958e-04 3.93403e-06
+        776    31 -228.041817 -228.041751 6.575087e-05   0.293 4.12174e-04 3.92203e-06
+        777    31 -228.041817 -228.041751 6.564931e-05   0.293 4.11393e-04 3.90964e-06
+        778    31 -228.041817 -228.041751 6.554933e-05   0.293 4.10616e-04 3.89688e-06
+        779    31 -228.041817 -228.041751 6.544749e-05   0.293 4.09843e-04 3.88374e-06
+        780    31 -228.041816 -228.041751 6.535353e-05   0.293 4.09076e-04 3.87024e-06
+        781    31 -228.041816 -228.041751 6.524833e-05   0.293 4.08308e-04 3.85638e-06
+        782    31 -228.041816 -228.041751 6.515407e-05   0.293 4.07548e-04 3.84217e-06
+        783    31 -228.041816 -228.041751 6.505328e-05   0.293 4.06790e-04 3.82763e-06
+        784    31 -228.041816 -228.041751 6.495781e-05   0.293 4.06036e-04 3.81277e-06
+        785    31 -228.041816 -228.041751 6.486086e-05   0.293 4.05286e-04 3.79759e-06
+        786    31 -228.041816 -228.041751 6.476482e-05   0.293 4.04540e-04 3.78212e-06
+        787    31 -228.041816 -228.041751 6.467979e-05   0.293 4.03802e-04 3.76636e-06
+        788    31 -228.041815 -228.041751 6.456718e-05   0.293 4.03058e-04 3.75034e-06
+        789    31 -228.041815 -228.041751 6.448351e-05   0.293 4.02326e-04 3.73406e-06
+        790    31 -228.041815 -228.041751 6.438359e-05   0.293 4.01593e-04 3.71754e-06
+        791    31 -228.041815 -228.041751 6.429397e-05   0.293 4.00867e-04 3.70081e-06
+        792    31 -228.041815 -228.041751 6.419664e-05   0.293 4.00141e-04 3.68386e-06
+        793    31 -228.041815 -228.041751 6.410748e-05   0.293 3.99422e-04 3.66673e-06
+        794    31 -228.041815 -228.041751 6.401479e-05   0.293 3.98706e-04 3.64943e-06
+        795    31 -228.041815 -228.041751 6.392407e-05   0.293 3.97993e-04 3.63196e-06
+        796    31 -228.041814 -228.041751 6.383488e-05   0.293 3.97285e-04 3.61435e-06
+        797    31 -228.041814 -228.041751 6.374136e-05   0.293 3.96579e-04 3.59661e-06
+        798    31 -228.041814 -228.041751 6.365269e-05   0.293 3.95878e-04 3.57877e-06
+        799    31 -228.041814 -228.041751 6.356515e-05   0.293 3.95181e-04 3.56083e-06
+        800    31 -228.041814 -228.041750 6.347159e-05   0.293 3.94484e-04 3.54281e-06
+        801    31 -228.041814 -228.041750 6.338718e-05   0.293 3.93794e-04 3.52473e-06
+        802    31 -228.041814 -228.041750 6.329662e-05   0.293 3.93106e-04 3.50661e-06
+        803    31 -228.041814 -228.041750 6.321021e-05   0.293 3.92422e-04 3.48845e-06
+        804    31 -228.041814 -228.041750 6.312169e-05   0.293 3.91741e-04 3.47026e-06
+        805    31 -228.041813 -228.041750 6.303601e-05   0.293 3.91063e-04 3.45207e-06
+        806    31 -228.041813 -228.041750 6.294834e-05   0.293 3.90389e-04 3.43389e-06
+        807    31 -228.041813 -228.041750 6.286253e-05   0.293 3.89718e-04 3.41572e-06
+        808    31 -228.041813 -228.041750 6.277703e-05   0.293 3.89050e-04 3.39759e-06
+        809    31 -228.041813 -228.041750 6.269138e-05   0.293 3.88386e-04 3.37950e-06
+        810    31 -228.041813 -228.041750 6.260796e-05   0.293 3.87725e-04 3.36146e-06
+        811    31 -228.041813 -228.041750 6.252294e-05   0.293 3.87067e-04 3.34348e-06
+        812    31 -228.041813 -228.041750 6.243882e-05   0.293 3.86413e-04 3.32557e-06
+        813    31 -228.041812 -228.041750 6.235502e-05   0.293 3.85761e-04 3.30775e-06
+        814    31 -228.041812 -228.041750 6.227145e-05   0.293 3.85113e-04 3.29002e-06
+        815    31 -228.041812 -228.041750 6.218882e-05   0.293 3.84467e-04 3.27239e-06
+        816    31 -228.041812 -228.041750 6.210756e-05   0.293 3.83825e-04 3.25487e-06
+        817    31 -228.041812 -228.041750 6.202245e-05   0.293 3.83185e-04 3.23747e-06
+        818    31 -228.041812 -228.041750 6.194259e-05   0.293 3.82549e-04 3.22019e-06
+        819    31 -228.041812 -228.041750 6.185970e-05   0.293 3.81915e-04 3.20303e-06
+        820    31 -228.041812 -228.041750 6.177878e-05   0.293 3.81284e-04 3.18601e-06
+        821    31 -228.041812 -228.041750 6.169737e-05   0.293 3.80656e-04 3.16914e-06
+        822    31 -228.041812 -228.041750 6.162010e-05   0.293 3.80033e-04 3.15240e-06
+        823    31 -228.041811 -228.041750 6.153471e-05   0.293 3.79409e-04 3.13582e-06
+        824    31 -228.041811 -228.041750 6.145851e-05   0.293 3.78791e-04 3.11938e-06
+        825    31 -228.041811 -228.041750 6.137619e-05   0.293 3.78173e-04 3.10311e-06
+        826    31 -228.041811 -228.041750 6.129801e-05   0.293 3.77559e-04 3.08699e-06
+        827    31 -228.041811 -228.041750 6.121819e-05   0.293 3.76948e-04 3.07104e-06
+        828    31 -228.041811 -228.041750 6.113925e-05   0.293 3.76339e-04 3.05526e-06
+        829    31 -228.041811 -228.041750 6.106188e-05   0.293 3.75733e-04 3.03964e-06
+        830    31 -228.041811 -228.041750 6.098229e-05   0.293 3.75129e-04 3.02419e-06
+        831    31 -228.041811 -228.041750 6.090531e-05   0.293 3.74529e-04 3.00891e-06
+        832    31 -228.041810 -228.041750 6.082902e-05   0.293 3.73931e-04 2.99380e-06
+        833    31 -228.041810 -228.041750 6.075514e-05   0.293 3.73337e-04 2.97886e-06
+        834    31 -228.041810 -228.041750 6.066987e-05   0.293 3.72741e-04 2.96410e-06
+        835    31 -228.041810 -228.041750 6.059784e-05   0.293 3.72152e-04 2.94951e-06
+        836    31 -228.041810 -228.041750 6.051810e-05   0.293 3.71562e-04 2.93509e-06
+        837    31 -228.041810 -228.041750 6.044209e-05   0.293 3.70976e-04 2.92085e-06
+        838    31 -228.041810 -228.041750 6.036696e-05   0.293 3.70392e-04 2.90677e-06
+        839    31 -228.041810 -228.041749 6.029054e-05   0.293 3.69810e-04 2.89287e-06
+        840    31 -228.041810 -228.041749 6.021651e-05   0.293 3.69232e-04 2.87914e-06
+        841    31 -228.041810 -228.041749 6.013938e-05   0.293 3.68655e-04 2.86558e-06
+        842    31 -228.041809 -228.041749 6.006579e-05   0.293 3.68081e-04 2.85218e-06
+        843    31 -228.041809 -228.041749 5.998955e-05   0.293 3.67508e-04 2.83895e-06
+        844    31 -228.041809 -228.041749 5.991882e-05   0.293 3.66940e-04 2.82588e-06
+        845    31 -228.041809 -228.041749 5.983963e-05   0.293 3.66371e-04 2.81297e-06
+        846    31 -228.041809 -228.041749 5.976859e-05   0.293 3.65806e-04 2.80023e-06
+        847    31 -228.041809 -228.041749 5.969255e-05   0.293 3.65242e-04 2.78764e-06
+        848    31 -228.041809 -228.041749 5.962119e-05   0.293 3.64682e-04 2.77522e-06
+        849    31 -228.041809 -228.041749 5.954575e-05   0.293 3.64122e-04 2.76294e-06
+        850    31 -228.041809 -228.041749 5.947419e-05   0.293 3.63565e-04 2.75082e-06
+        851    31 -228.041809 -228.041749 5.940066e-05   0.293 3.63011e-04 2.73884e-06
+        852    31 -228.041809 -228.041749 5.932848e-05   0.293 3.62458e-04 2.72702e-06
+        853    31 -228.041808 -228.041749 5.925438e-05   0.293 3.61907e-04 2.71533e-06
+        854    31 -228.041808 -228.041749 5.918418e-05   0.293 3.61359e-04 2.70379e-06
+        855    31 -228.041808 -228.041749 5.911104e-05   0.293 3.60812e-04 2.69239e-06
+        856    31 -228.041808 -228.041749 5.904272e-05   0.293 3.60269e-04 2.68112e-06
+        857    31 -228.041808 -228.041749 5.896580e-05   0.293 3.59725e-04 2.66998e-06
+        858    31 -228.041808 -228.041749 5.889446e-05   0.293 3.59184e-04 2.65898e-06
+        859    31 -228.041808 -228.041749 5.882085e-05   0.293 3.58644e-04 2.64811e-06
+        860    31 -228.041808 -228.041749 5.875823e-05   0.293 3.58110e-04 2.63736e-06
+        861    31 -228.041808 -228.041749 5.868235e-05   0.293 3.57574e-04 2.62674e-06
+        862    31 -228.041808 -228.041749 5.861326e-05   0.293 3.57041e-04 2.61624e-06
+        863    31 -228.041808 -228.041749 5.854375e-05   0.293 3.56511e-04 2.60585e-06
+        864    31 -228.041807 -228.041749 5.847366e-05   0.293 3.55982e-04 2.59558e-06
+        865    31 -228.041807 -228.041749 5.840431e-05   0.293 3.55455e-04 2.58541e-06
+        866    31 -228.041807 -228.041749 5.833427e-05   0.293 3.54930e-04 2.57536e-06
+        867    31 -228.041807 -228.041749 5.826526e-05   0.293 3.54407e-04 2.56542e-06
+        868    31 -228.041807 -228.041749 5.819604e-05   0.293 3.53885e-04 2.55559e-06
+        869    31 -228.041807 -228.041749 5.812641e-05   0.293 3.53365e-04 2.54586e-06
+        870    31 -228.041807 -228.041749 5.805892e-05   0.293 3.52848e-04 2.53622e-06
+        871    31 -228.041807 -228.041749 5.798970e-05   0.293 3.52331e-04 2.52669e-06
+        872    31 -228.041807 -228.041749 5.792793e-05   0.293 3.51820e-04 2.51725e-06
+        873    31 -228.041807 -228.041749 5.784847e-05   0.293 3.51303e-04 2.50791e-06
+        874    31 -228.041807 -228.041749 5.778764e-05   0.293 3.50794e-04 2.49866e-06
+        875    31 -228.041806 -228.041749 5.771686e-05   0.293 3.50284e-04 2.48950e-06
+        876    31 -228.041806 -228.041749 5.765088e-05   0.293 3.49777e-04 2.48043e-06
+        877    31 -228.041806 -228.041749 5.758365e-05   0.293 3.49272e-04 2.47144e-06
+        878    31 -228.041806 -228.041749 5.751519e-05   0.293 3.48767e-04 2.46254e-06
+        879    31 -228.041806 -228.041749 5.744953e-05   0.293 3.48265e-04 2.45372e-06
+        880    31 -228.041806 -228.041749 5.738174e-05   0.293 3.47764e-04 2.44499e-06
+        881    31 -228.041806 -228.041749 5.731580e-05   0.293 3.47265e-04 2.43633e-06
+        882    31 -228.041806 -228.041749 5.724895e-05   0.293 3.46767e-04 2.42776e-06
+        883    31 -228.041806 -228.041749 5.718280e-05   0.293 3.46271e-04 2.41926e-06
+        884    31 -228.041806 -228.041749 5.711619e-05   0.293 3.45776e-04 2.41084e-06
+        885    31 -228.041806 -228.041749 5.705027e-05   0.293 3.45283e-04 2.40250e-06
+        886    31 -228.041805 -228.041748 5.698463e-05   0.293 3.44791e-04 2.39424e-06
+        887    31 -228.041805 -228.041748 5.691864e-05   0.293 3.44301e-04 2.38606e-06
+        888    31 -228.041805 -228.041748 5.685361e-05   0.293 3.43812e-04 2.37796e-06
+        889    31 -228.041805 -228.041748 5.678767e-05   0.293 3.43324e-04 2.36995e-06
+        890    31 -228.041805 -228.041748 5.672266e-05   0.293 3.42837e-04 2.36204e-06
+        891    31 -228.041805 -228.041748 5.665724e-05   0.293 3.42351e-04 2.35424e-06
+        892    31 -228.041799 -228.041748 5.041408e-05   0.293 3.07639e-04 7.10259e-06
+        893    28 -228.041786 -228.041753 3.254214e-05   0.293 2.72013e-04 1.64401e-05
+        894    28 -228.041785 -228.041762 2.307763e-05   0.293 2.81133e-04 1.53498e-05
+        895    24 -228.041780 -228.041758 2.215171e-05   0.293 2.84916e-04 1.15069e-05
+        896    28 -228.041780 -228.041757 2.216216e-05   0.293 2.89392e-04 7.11841e-06
+        897    28 -228.041781 -228.041755 2.596569e-05   0.293 2.89056e-04 5.92839e-06
+        898    28 -228.041784 -228.041754 2.945043e-05   0.293 2.89772e-04 6.57185e-06
+        899    28 -228.041786 -228.041753 3.322613e-05   0.293 2.90550e-04 6.23608e-06
+        900    28 -228.041787 -228.041751 3.622272e-05   0.293 2.91941e-04 5.01290e-06
+        901    31 -228.041788 -228.041749 3.871844e-05   0.293 2.90988e-04 4.09289e-06
+        902    31 -228.041787 -228.041747 4.046316e-05   0.293 2.88964e-04 4.11955e-06
+        903    31 -228.041786 -228.041745 4.137660e-05   0.293 2.86411e-04 4.31042e-06
+        904    31 -228.041786 -228.041744 4.139117e-05   0.293 2.84474e-04 4.04858e-06
+        905    31 -228.041785 -228.041744 4.072520e-05   0.293 2.83184e-04 3.45558e-06
+        906    31 -228.041785 -228.041745 3.978937e-05   0.293 2.82557e-04 2.95294e-06
+        907    31 -228.041786 -228.041747 3.903151e-05   0.293 2.82479e-04 2.75329e-06
+        908    31 -228.041787 -228.041748 3.872667e-05   0.293 2.82884e-04 2.67337e-06
+        909    31 -228.041788 -228.041749 3.886801e-05   0.293 2.83523e-04 2.51212e-06
+        910    31 -228.041788 -228.041749 3.920730e-05   0.293 2.84088e-04 2.27574e-06
+        911    31 -228.041788 -228.041749 3.943771e-05   0.293 2.84347e-04 2.08032e-06
+        912    31 -228.041788 -228.041749 3.932339e-05   0.293 2.84245e-04 2.00162e-06
+        913    31 -228.041788 -228.041749 3.883344e-05   0.293 2.83875e-04 2.01694e-06
+        914    31 -228.041787 -228.041749 3.809889e-05   0.293 2.83374e-04 2.06374e-06
+        915    31 -228.041787 -228.041749 3.734980e-05   0.293 2.82856e-04 2.09790e-06
+        916    31 -228.041786 -228.041749 3.679288e-05   0.293 2.82379e-04 2.10006e-06
+        917    31 -228.041786 -228.041749 3.654502e-05   0.293 2.81955e-04 2.06943e-06
+        918    31 -228.041786 -228.041749 3.660948e-05   0.293 2.81560e-04 2.02140e-06
+        919    31 -228.041786 -228.041749 3.689966e-05   0.293 2.81151e-04 1.98029e-06
+        920    31 -228.041786 -228.041748 3.729280e-05   0.293 2.80697e-04 1.96388e-06
+        921    31 -228.041786 -228.041748 3.767378e-05   0.293 2.80183e-04 1.97093e-06
+        922    31 -228.041786 -228.041748 3.796268e-05   0.293 2.79617e-04 1.98392e-06
+        923    31 -228.041785 -228.041747 3.812742e-05   0.293 2.79023e-04 1.98365e-06
+        924    31 -228.041785 -228.041747 3.816578e-05   0.293 2.78428e-04 1.96225e-06
+        925    31 -228.041785 -228.041747 3.810247e-05   0.293 2.77860e-04 1.92624e-06
+        926    31 -228.041785 -228.041747 3.796483e-05   0.293 2.77337e-04 1.89029e-06
+        927    31 -228.041785 -228.041747 3.777763e-05   0.293 2.76867e-04 1.86655e-06
+        928    31 -228.041785 -228.041747 3.756564e-05   0.293 2.76453e-04 1.85733e-06
+        929    31 -228.041785 -228.041748 3.734714e-05   0.293 2.76090e-04 1.85622e-06
+        930    31 -228.041785 -228.041748 3.713985e-05   0.293 2.75768e-04 1.85523e-06
+        931    31 -228.041785 -228.041748 3.695794e-05   0.293 2.75476e-04 1.85086e-06
+        932    31 -228.041785 -228.041748 3.681217e-05   0.293 2.75203e-04 1.84490e-06
+        933    31 -228.041785 -228.041748 3.670954e-05   0.293 2.74939e-04 1.84119e-06
+        934    31 -228.041785 -228.041748 3.665071e-05   0.293 2.74681e-04 1.84175e-06
+        935    31 -228.041785 -228.041748 3.662827e-05   0.293 2.74422e-04 1.84529e-06
+        936    31 -228.041785 -228.041748 3.663725e-05   0.293 2.74162e-04 1.84853e-06
+        937    31 -228.041785 -228.041748 3.666423e-05   0.293 2.73899e-04 1.84864e-06
+        938    31 -228.041784 -228.041748 3.670143e-05   0.293 2.73634e-04 1.84494e-06
+        939    31 -228.041784 -228.041748 3.673596e-05   0.293 2.73361e-04 1.83884e-06
+        940    31 -228.041784 -228.041748 3.676698e-05   0.293 2.73083e-04 1.83257e-06
+        941    31 -228.041784 -228.041748 3.678542e-05   0.293 2.72796e-04 1.82763e-06
+        942    31 -228.041784 -228.041748 3.679268e-05   0.293 2.72501e-04 1.82424e-06
+        943    31 -228.041784 -228.041748 3.678490e-05   0.293 2.72197e-04 1.82172e-06
+        944    31 -228.041784 -228.041748 3.676228e-05   0.293 2.71887e-04 1.81945e-06
+        945    31 -228.041784 -228.041748 3.672545e-05   0.293 2.71572e-04 1.81754e-06
+        946    31 -228.041784 -228.041748 3.667389e-05   0.293 2.71254e-04 1.81690e-06
+        947    31 -228.041784 -228.041748 3.660851e-05   0.293 2.70933e-04 1.81877e-06
+        948    31 -228.041784 -228.041748 3.653309e-05   0.293 2.70611e-04 1.82426e-06
+        949    31 -228.041784 -228.041748 3.644319e-05   0.293 2.70284e-04 1.83440e-06
+        950    31 -228.041784 -228.041748 3.634750e-05   0.293 2.69951e-04 1.85078e-06
+        951    31 -228.041784 -228.041748 3.624102e-05   0.293 2.69602e-04 1.87678e-06
+        952    31 -228.041784 -228.041748 3.612669e-05   0.293 2.69231e-04 1.91974e-06
+        953    31 -228.041784 -228.041748 3.599712e-05   0.293 2.68819e-04 1.99521e-06
+        954    31 -228.041784 -228.041748 3.584461e-05   0.293 2.68339e-04 2.13833e-06
+        955    31 -228.041783 -228.041748 3.564998e-05   0.293 2.67733e-04 2.44029e-06
+        956    31 -228.041783 -228.041748 3.536507e-05   0.293 2.66846e-04 3.20809e-06
+        957    31 -228.041771 -228.041748 2.358571e-05   0.293 2.03400e-04 1.78842e-05
+        958    23 -228.041760 -228.041757 3.245312e-06   0.293 1.89731e-04 1.63551e-05
+        959    23 -228.041749 -228.041763 1.333719e-05   0.293 1.96238e-04 1.94283e-05
+        960    23 -228.041738 -228.041765 2.658557e-05   0.293 2.19529e-04 1.94418e-05
+        961    24 -228.041730 -228.041767 3.660146e-05   0.293 2.41111e-04 1.72254e-05
+        962    23 -228.041725 -228.041767 4.164871e-05   0.293 2.50514e-04 1.41211e-05
+        963    26 -228.041724 -228.041766 4.233924e-05   0.293 2.46081e-04 1.12764e-05
+        964    28 -228.041726 -228.041764 3.869142e-05   0.293 2.32385e-04 9.41432e-06
+        965    27 -228.041729 -228.041761 3.188735e-05   0.293 2.15581e-04 8.58796e-06
+        966    28 -228.041733 -228.041756 2.289789e-05   0.293 2.01040e-04 8.41758e-06
+        967    26 -228.041737 -228.041750 1.344968e-05   0.293 1.91082e-04 8.58041e-06
+        968    28 -228.041740 -228.041745 4.850922e-06   0.293 1.85565e-04 8.85927e-06
+        969    27 -228.041742 -228.041741 1.710639e-06   0.293 1.83282e-04 9.00332e-06
+        970    28 -228.041744 -228.041738 5.818453e-06   0.293 1.83323e-04 8.76495e-06
+        971    27 -228.041745 -228.041737 7.524214e-06   0.293 1.84987e-04 8.01877e-06
+        972    23 -228.041745 -228.041737 7.367640e-06   0.293 1.87482e-04 6.81995e-06
+        973    28 -228.041746 -228.041739 6.271504e-06   0.293 1.89885e-04 5.37389e-06
+        974    26 -228.041746 -228.041742 4.358712e-06   0.293 1.91417e-04 4.05439e-06
+        975    28 -228.041746 -228.041744 2.456295e-06   0.293 1.91856e-04 3.32102e-06
+        976    28 -228.041747 -228.041746 3.932273e-07   0.293 1.91441e-04 3.34070e-06
+        977    28 -228.041747 -228.041748 1.661056e-06   0.293 1.90636e-04 3.69177e-06
+        978    28 -228.041746 -228.041750 3.841435e-06   0.293 1.89913e-04 3.94439e-06
+        979    28 -228.041745 -228.041751 6.058596e-06   0.293 1.89560e-04 3.95069e-06
+        980    28 -228.041744 -228.041752 8.172512e-06   0.293 1.89638e-04 3.74048e-06
+        981    28 -228.041743 -228.041753 9.977224e-06   0.293 1.90032e-04 3.42102e-06
+        982    28 -228.041742 -228.041753 1.125827e-05   0.293 1.90526e-04 3.11037e-06
+        983    28 -228.041741 -228.041753 1.182922e-05   0.293 1.90889e-04 2.88448e-06
+        984    30 -228.041740 -228.041752 1.165228e-05   0.293 1.90960e-04 2.75251e-06
+        985    29 -228.041740 -228.041751 1.068882e-05   0.293 1.90654e-04 2.67503e-06
+        986    31 -228.041740 -228.041749 9.193366e-06   0.293 1.90053e-04 2.61292e-06
+        987    31 -228.041740 -228.041748 7.272730e-06   0.293 1.89254e-04 2.54841e-06
+        988    31 -228.041741 -228.041746 5.283812e-06   0.293 1.88448e-04 2.47885e-06
+        989    31 -228.041741 -228.041745 3.425920e-06   0.293 1.87771e-04 2.40093e-06
+        990    31 -228.041742 -228.041744 1.967516e-06   0.293 1.87347e-04 2.30373e-06
+        991    30 -228.041742 -228.041743 1.012502e-06   0.293 1.87217e-04 2.17446e-06
+        992    29 -228.041743 -228.041743 7.170379e-07   0.293 1.87398e-04 2.00884e-06
+        993    31 -228.041743 -228.041744 9.381887e-07   0.293 1.87808e-04 1.81750e-06
+        994    31 -228.041743 -228.041745 1.669444e-06   0.293 1.88374e-04 1.62532e-06
+        995    31 -228.041743 -228.041745 2.701592e-06   0.293 1.88972e-04 1.46331e-06
+        996    31 -228.041743 -228.041746 3.896271e-06   0.293 1.89496e-04 1.35522e-06
+        997    31 -228.041742 -228.041747 5.064154e-06   0.293 1.89856e-04 1.30475e-06
+        998    31 -228.041742 -228.041748 6.078747e-06   0.293 1.90005e-04 1.29514e-06
+        999    31 -228.041742 -228.041749 6.840686e-06   0.293 1.89936e-04 1.30212e-06
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization did not converge in  20 iterations 
+            Total energy change: -2.679072e-04
+            Final gradient norm: 1.892856e-04
+
+       1000    31 -228.042010 -228.045349 3.339450e-03  42.554 1.89678e-04 1.30679e-06
+       1001    46 -228.042734 -228.038359 4.374346e-03  42.554 1.68516e-03 1.64764e-01
+       1002    31 -228.043069 -228.085116 4.204710e-02  42.554 2.04523e-03 1.29757e-01
+       1003    31 -228.043440 -228.138211 9.477116e-02  42.554 1.71301e-03 1.16796e-01
+       1004    31 -228.043587 -228.160997 1.174105e-01  42.554 1.38952e-03 1.23189e-01
+       1005    32 -228.043703 -228.172208 1.285043e-01  42.554 1.20214e-03 1.19820e-01
+       1006    32 -228.043666 -228.142757 9.909006e-02  42.554 7.18842e-04 1.16274e-01
+       1007    32 -228.043713 -228.135381 9.166831e-02  42.554 7.76791e-04 1.09476e-01
+       1008    32 -228.043893 -228.128009 8.411526e-02  42.554 7.93526e-04 1.03504e-01
+       1009    32 -228.044138 -228.118156 7.401811e-02  42.554 7.04166e-04 1.00342e-01
+       1010    32 -228.044433 -228.096976 5.254319e-02  42.554 5.83051e-04 9.83565e-02
+       1011    32 -228.044720 -228.078292 3.357200e-02  42.554 4.95079e-04 9.66089e-02
+       1012    32 -228.044999 -228.068609 2.361000e-02  42.554 4.16503e-04 9.50619e-02
+       1013    32 -228.045251 -228.066076 2.082574e-02  42.554 3.35461e-04 9.37777e-02
+       1014    32 -228.045481 -228.072248 2.676613e-02  42.554 2.92916e-04 9.19472e-02
+       1015    32 -228.045686 -228.076711 3.102407e-02  42.554 2.94518e-04 9.02371e-02
+       1016    32 -228.045868 -228.081234 3.536543e-02  42.554 3.13803e-04 8.85195e-02
+       1017    32 -228.046034 -228.083526 3.749160e-02  42.554 3.12038e-04 8.70144e-02
+       1018    32 -228.046192 -228.084952 3.875991e-02  42.554 2.76502e-04 8.57629e-02
+       1019    32 -228.046345 -228.086343 3.999775e-02  42.554 2.13640e-04 8.47676e-02
+       1020    32 -228.046491 -228.088472 4.198077e-02  42.554 1.59470e-04 8.37982e-02
+       1021    32 -228.046640 -228.093635 4.699530e-02  42.554 1.45219e-04 8.27146e-02
+       1022    32 -228.046786 -228.098192 5.140558e-02  42.554 1.70760e-04 8.15260e-02
+       1023    32 -228.046928 -228.100054 5.312621e-02  42.554 1.97362e-04 8.03781e-02
+       1024    32 -228.047065 -228.099241 5.217580e-02  42.554 1.99948e-04 7.93740e-02
+       1025    32 -228.047202 -228.096487 4.928496e-02  42.554 1.72707e-04 7.85061e-02
+       1026    32 -228.047338 -228.092837 4.549886e-02  42.554 1.28810e-04 7.76864e-02
+       1027    32 -228.047482 -228.090009 4.252732e-02  42.554 1.02886e-04 7.68268e-02
+       1028    32 -228.047628 -228.087157 3.952875e-02  42.554 1.18701e-04 7.59347e-02
+       1029    32 -228.047772 -228.085017 3.724487e-02  42.554 1.49810e-04 7.50375e-02
+       1030    32 -228.047913 -228.084429 3.651567e-02  42.554 1.64416e-04 7.41709e-02
+       1031    32 -228.048048 -228.085157 3.710873e-02  42.554 1.55575e-04 7.33533e-02
+       1032    32 -228.048176 -228.086749 3.857317e-02  42.554 1.29075e-04 7.25791e-02
+       1033    32 -228.048296 -228.088701 4.040473e-02  42.554 9.87033e-05 7.18300e-02
+       1034    32 -228.048410 -228.090605 4.219486e-02  42.554 8.09912e-05 7.10893e-02
+       1035    32 -228.048520 -228.092145 4.362516e-02  42.554 8.17547e-05 7.03489e-02
+       1036    32 -228.048628 -228.093082 4.445466e-02  42.554 8.93097e-05 6.96107e-02
+       1037    32 -228.048736 -228.093289 4.455380e-02  42.554 9.32390e-05 6.88834e-02
+       1038    32 -228.048844 -228.092790 4.394621e-02  42.554 9.10080e-05 6.81778e-02
+       1039    32 -228.048952 -228.091772 4.281998e-02  42.554 8.39287e-05 6.75019e-02
+       1040    32 -228.049060 -228.090547 4.148693e-02  42.554 7.43210e-05 6.68571e-02
+       1041    32 -228.049167 -228.089459 4.029284e-02  42.554 6.47092e-05 6.62372e-02
+       1042    32 -228.049271 -228.088787 3.951579e-02  42.554 5.79132e-05 6.56327e-02
+       1043    32 -228.049372 -228.088662 3.928972e-02  42.554 5.61240e-05 6.50359e-02
+       1044    32 -228.049471 -228.089055 3.958407e-02  42.554 5.88768e-05 6.44418e-02
+       1045    32 -228.049568 -228.089947 4.037977e-02  42.554 6.69370e-05 6.38489e-02
+       1046    32 -228.049664 -228.091745 4.208126e-02  42.554 6.80884e-05 6.32678e-02
+       1047    32 -228.049754 -228.093240 4.348579e-02  42.554 6.88649e-05 6.27062e-02
+       1048    32 -228.049841 -228.094774 4.493321e-02  42.554 6.67873e-05 6.21612e-02
+       1049    32 -228.049926 -228.095564 4.563746e-02  42.554 6.34440e-05 6.16338e-02
+       1050    32 -228.050011 -228.095702 4.569124e-02  42.554 6.04759e-05 6.11142e-02
+       1051    32 -228.050096 -228.095368 4.527226e-02  42.554 5.51942e-05 6.06036e-02
+       1052    32 -228.050181 -228.094603 4.442177e-02  42.554 4.83848e-05 6.01041e-02
+       1053    32 -228.050267 -228.093546 4.327846e-02  42.554 4.22168e-05 5.96171e-02
+       1054    32 -228.050353 -228.092405 4.205248e-02  42.554 3.80171e-05 5.91432e-02
+       1055    32 -228.050437 -228.091416 4.097876e-02  42.554 3.62049e-05 5.86809e-02
+       1056    32 -228.050520 -228.090735 4.021464e-02  42.554 3.67698e-05 5.82277e-02
+       1057    32 -228.050601 -228.090412 3.981067e-02  42.554 3.89382e-05 5.77826e-02
+       1058    32 -228.050680 -228.090398 3.971775e-02  42.554 4.13306e-05 5.73459e-02
+       1059    32 -228.050757 -228.090584 3.982702e-02  42.554 4.26590e-05 5.69189e-02
+       1060    32 -228.050832 -228.090841 4.000938e-02  42.554 4.22227e-05 5.65025e-02
+       1061    32 -228.050905 -228.091051 4.014587e-02  42.554 4.00741e-05 5.60968e-02
+       1062    32 -228.050976 -228.091123 4.014692e-02  42.554 3.69518e-05 5.57008e-02
+       1063    32 -228.051047 -228.091008 3.996182e-02  42.554 3.40152e-05 5.53132e-02
+       1064    32 -228.051116 -228.090697 3.958140e-02  42.554 3.22885e-05 5.49330e-02
+       1065    32 -228.051184 -228.090217 3.903300e-02  42.554 3.19932e-05 5.45600e-02
+       1066    32 -228.051252 -228.089623 3.837101e-02  42.554 3.24491e-05 5.41944e-02
+       1067    32 -228.051320 -228.088983 3.766289e-02  42.554 3.27245e-05 5.38369e-02
+       1068    32 -228.051388 -228.088363 3.697485e-02  42.554 3.22640e-05 5.34876e-02
+       1069    32 -228.051455 -228.087815 3.635976e-02  42.554 3.10775e-05 5.31465e-02
+       1070    32 -228.051522 -228.087372 3.585006e-02  42.554 2.96293e-05 5.28128e-02
+       1071    32 -228.051589 -228.087045 3.545590e-02  42.554 2.85505e-05 5.24862e-02
+       1072    32 -228.051654 -228.086822 3.516797e-02  42.554 2.82518e-05 5.21660e-02
+       1073    32 -228.051719 -228.086682 3.496314e-02  42.554 2.86587e-05 5.18521e-02
+       1074    32 -228.051783 -228.086594 3.481125e-02  42.554 2.93138e-05 5.15444e-02
+       1075    32 -228.051845 -228.086527 3.468137e-02  42.554 2.97068e-05 5.12431e-02
+       1076    32 -228.051907 -228.086453 3.454652e-02  42.554 2.95209e-05 5.09480e-02
+       1077    32 -228.051967 -228.086354 3.438661e-02  42.554 2.87030e-05 5.06593e-02
+       1078    32 -228.052027 -228.086216 3.418955e-02  42.554 2.74246e-05 5.03768e-02
+       1079    32 -228.052085 -228.086036 3.395098e-02  42.554 2.59908e-05 5.01002e-02
+       1080    32 -228.052143 -228.085816 3.367342e-02  42.554 2.38387e-05 4.98293e-02
+       1081    32 -228.052199 -228.085610 3.341089e-02  42.554 2.28231e-05 4.95639e-02
+       1082    32 -228.052255 -228.085403 3.314753e-02  42.554 2.30402e-05 4.93038e-02
+       1083    32 -228.052311 -228.085132 3.282099e-02  42.554 2.38936e-05 4.90490e-02
+       1084    32 -228.052367 -228.084867 3.250046e-02  42.554 2.42656e-05 4.87994e-02
+       1085    32 -228.052422 -228.084596 3.217354e-02  42.554 2.39286e-05 4.85550e-02
+       1086    32 -228.052478 -228.084320 3.184217e-02  42.554 2.31009e-05 4.83155e-02
+       1087    32 -228.052533 -228.084017 3.148421e-02  42.554 2.23203e-05 4.80806e-02
+       1088    32 -228.052587 -228.083702 3.111479e-02  42.554 2.17953e-05 4.78503e-02
+       1089    32 -228.052641 -228.083395 3.075418e-02  42.554 2.14659e-05 4.76243e-02
+       1090    32 -228.052694 -228.083123 3.042844e-02  42.554 2.12159e-05 4.74025e-02
+       1091    32 -228.052747 -228.082895 3.014899e-02  42.554 2.10170e-05 4.71850e-02
+       1092    32 -228.052798 -228.082709 2.991083e-02  42.554 2.08674e-05 4.69716e-02
+       1093    32 -228.052850 -228.082548 2.969786e-02  42.554 2.07212e-05 4.67623e-02
+       1094    32 -228.052901 -228.082390 2.948943e-02  42.554 2.05138e-05 4.65571e-02
+       1095    32 -228.052951 -228.082208 2.925643e-02  42.554 2.02439e-05 4.63558e-02
+       1096    32 -228.053001 -228.081995 2.899333e-02  42.554 1.99128e-05 4.61583e-02
+       1097    32 -228.053051 -228.081767 2.871534e-02  42.554 1.95365e-05 4.59645e-02
+       1098    32 -228.053101 -228.081522 2.842185e-02  42.554 1.91793e-05 4.57743e-02
+       1099    32 -228.053150 -228.081272 2.812259e-02  42.554 1.88620e-05 4.55876e-02
+       1100    32 -228.053198 -228.081020 2.782147e-02  42.554 1.86092e-05 4.54043e-02
+       1101    32 -228.053246 -228.080772 2.752592e-02  42.554 1.84143e-05 4.52244e-02
+       1102    32 -228.053294 -228.080536 2.724207e-02  42.554 1.82670e-05 4.50476e-02
+       1103    32 -228.053342 -228.080316 2.697435e-02  42.554 1.81502e-05 4.48741e-02
+       1104    32 -228.053389 -228.080112 2.672342e-02  42.554 1.80453e-05 4.47036e-02
+       1105    32 -228.053436 -228.079922 2.648672e-02  42.554 1.79317e-05 4.45361e-02
+       1106    32 -228.053482 -228.079741 2.625940e-02  42.554 1.77926e-05 4.43715e-02
+       1107    32 -228.053528 -228.079564 2.603591e-02  42.554 1.76193e-05 4.42097e-02
+       1108    32 -228.053574 -228.079385 2.581120e-02  42.554 1.74145e-05 4.40508e-02
+       1109    32 -228.053619 -228.079200 2.558149e-02  42.554 1.71898e-05 4.38945e-02
+       1110    32 -228.053664 -228.079009 2.534455e-02  42.554 1.69610e-05 4.37408e-02
+       1111    32 -228.053709 -228.078809 2.509974e-02  42.554 1.67419e-05 4.35898e-02
+       1112    32 -228.053753 -228.078601 2.484778e-02  42.554 1.65405e-05 4.34412e-02
+       1113    32 -228.053797 -228.078388 2.459048e-02  42.554 1.63583e-05 4.32950e-02
+       1114    32 -228.053841 -228.078172 2.433035e-02  42.554 1.61912e-05 4.31513e-02
+       1115    32 -228.053885 -228.077955 2.407016e-02  42.554 1.60334e-05 4.30099e-02
+       1116    32 -228.053928 -228.077740 2.381243e-02  42.554 1.58796e-05 4.28707e-02
+       1117    32 -228.053971 -228.077530 2.355917e-02  42.554 1.57267e-05 4.27338e-02
+       1118    32 -228.054014 -228.077325 2.331157e-02  42.554 1.55737e-05 4.25990e-02
+       1119    32 -228.054056 -228.077126 2.307001e-02  42.554 1.54209e-05 4.24663e-02
+       1120    32 -228.054098 -228.076933 2.283419e-02  42.554 1.52693e-05 4.23357e-02
+       1121    32 -228.054140 -228.076744 2.260328e-02  42.554 1.51204e-05 4.22070e-02
+       1122    32 -228.054181 -228.076558 2.237725e-02  42.554 1.73132e-05 4.20742e-02
+       1123    32 -228.054222 -228.076982 2.275925e-02  42.554 2.12649e-05 4.19436e-02
+       1124    32 -228.054264 -228.077611 2.334618e-02  42.554 2.12475e-05 4.18161e-02
+       1125    32 -228.054306 -228.077810 2.350349e-02  42.554 1.95381e-05 4.16928e-02
+       1126    32 -228.054348 -228.077665 2.331675e-02  42.554 1.76150e-05 4.15731e-02
+       1127    32 -228.054388 -228.077306 2.291817e-02  42.554 1.61867e-05 4.14551e-02
+       1128    32 -228.054428 -228.076978 2.254983e-02  42.554 1.60042e-05 4.13378e-02
+       1129    32 -228.054467 -228.076786 2.231857e-02  42.554 1.68361e-05 4.12216e-02
+       1130    32 -228.054507 -228.076725 2.221825e-02  42.554 1.71445e-05 4.11070e-02
+       1131    32 -228.054546 -228.076706 2.215989e-02  42.554 1.61978e-05 4.09947e-02
+       1132    32 -228.054585 -228.076637 2.205138e-02  42.554 1.46379e-05 4.08845e-02
+       1133    32 -228.054625 -228.076470 2.184517e-02  42.554 1.35615e-05 4.07756e-02
+       1134    32 -228.054664 -228.076213 2.154991e-02  42.554 1.33402e-05 4.06678e-02
+       1135    32 -228.054702 -228.075913 2.121091e-02  42.554 1.34928e-05 4.05612e-02
+       1136    32 -228.054741 -228.075621 2.088045e-02  42.554 1.35568e-05 4.04558e-02
+       1137    32 -228.054779 -228.075374 2.059488e-02  42.554 1.34892e-05 4.03520e-02
+       1138    32 -228.054817 -228.075184 2.036656e-02  42.554 1.34465e-05 4.02496e-02
+       1139    32 -228.054855 -228.075043 2.018843e-02  42.554 1.34934e-05 4.01484e-02
+       1140    32 -228.054893 -228.074937 2.004428e-02  42.554 1.35223e-05 4.00484e-02
+       1141    32 -228.054931 -228.074849 1.991777e-02  42.554 1.33711e-05 3.99496e-02
+       1142    32 -228.054968 -228.074765 1.979705e-02  42.554 1.29706e-05 3.98521e-02
+       1143    32 -228.055006 -228.074681 1.967509e-02  42.554 1.24005e-05 3.97558e-02
+       1144    32 -228.055043 -228.074591 1.954776e-02  42.554 1.18407e-05 3.96607e-02
+       1145    32 -228.055080 -228.074492 1.941198e-02  42.554 1.14563e-05 3.95666e-02
+       1146    32 -228.055116 -228.074381 1.926495e-02  42.554 1.12984e-05 3.94736e-02
+       1147    32 -228.055153 -228.074257 1.910462e-02  42.554 1.13006e-05 3.93816e-02
+       1148    32 -228.055189 -228.074119 1.893050e-02  42.554 1.13590e-05 3.92906e-02
+       1149    32 -228.055225 -228.073969 1.874425e-02  42.554 1.14023e-05 3.92006e-02
+       1150    32 -228.055261 -228.073810 1.854952e-02  42.554 1.14020e-05 3.91116e-02
+       1151    32 -228.055297 -228.073648 1.835122e-02  42.554 1.13490e-05 3.90236e-02
+       1152    32 -228.055332 -228.073487 1.815446e-02  42.554 1.12358e-05 3.89365e-02
+       1153    32 -228.055368 -228.073331 1.796363e-02  42.554 1.10582e-05 3.88503e-02
+       1154    32 -228.055403 -228.073185 1.778178e-02  42.554 1.08267e-05 3.87649e-02
+       1155    32 -228.055438 -228.073049 1.761035e-02  42.554 1.05685e-05 3.86805e-02
+       1156    32 -228.055474 -228.072923 1.744919e-02  42.554 1.03173e-05 3.85969e-02
+       1157    32 -228.055509 -228.072805 1.729681e-02  42.554 1.00975e-05 3.85141e-02
+       1158    32 -228.055543 -228.072694 1.715080e-02  42.554 9.91781e-06 3.84321e-02
+       1159    32 -228.055578 -228.072586 1.700832e-02  42.554 9.77394e-06 3.83509e-02
+       1160    32 -228.055613 -228.072479 1.686663e-02  42.554 9.65702e-06 3.82705e-02
+       1161    32 -228.055647 -228.072371 1.672363e-02  42.554 9.55775e-06 3.81909e-02
+       1162    32 -228.055681 -228.072259 1.657813e-02  42.554 9.46600e-06 3.81120e-02
+       1163    32 -228.055715 -228.072145 1.643000e-02  42.554 9.37010e-06 3.80338e-02
+       1164    32 -228.055749 -228.072029 1.628000e-02  42.554 9.25930e-06 3.79564e-02
+       1165    32 -228.055783 -228.071912 1.612949e-02  42.554 9.12854e-06 3.78796e-02
+       1166    32 -228.055816 -228.071796 1.597996e-02  42.554 8.98128e-06 3.78035e-02
+       1167    32 -228.055850 -228.071683 1.583269e-02  42.554 8.82784e-06 3.77281e-02
+       1168    32 -228.055883 -228.071572 1.568840e-02  42.554 8.68010e-06 3.76534e-02
+       1169    32 -228.055917 -228.071464 1.554718e-02  42.554 8.54596e-06 3.75792e-02
+       1170    32 -228.055950 -228.071358 1.540853e-02  42.554 8.42680e-06 3.75057e-02
+       1171    32 -228.055983 -228.071254 1.527155e-02  42.554 8.31864e-06 3.74328e-02
+       1172    32 -228.056015 -228.071151 1.513520e-02  42.554 8.21517e-06 3.73605e-02
+       1173    32 -228.056048 -228.071047 1.499855e-02  42.554 8.11047e-06 3.72887e-02
+       1174    32 -228.056081 -228.070942 1.486096e-02  42.554 8.00036e-06 3.72176e-02
+       1175    32 -228.056113 -228.070835 1.472224e-02  42.554 7.88260e-06 3.71469e-02
+       1176    32 -228.056146 -228.070728 1.458262e-02  42.554 7.75668e-06 3.70769e-02
+       1177    32 -228.056178 -228.070620 1.444269e-02  42.554 7.62361e-06 3.70073e-02
+       1178    32 -228.056210 -228.070513 1.430326e-02  42.554 7.48558e-06 3.69383e-02
+       1179    32 -228.056242 -228.070407 1.416523e-02  42.554 7.34541e-06 3.68698e-02
+       1180    32 -228.056274 -228.070303 1.402938e-02  42.554 7.20585e-06 3.68019e-02
+       1181    32 -228.056306 -228.070202 1.389630e-02  42.554 7.06898e-06 3.67343e-02
+       1182    32 -228.056337 -228.070103 1.376627e-02  42.554 6.93597e-06 3.66673e-02
+       1183    32 -228.056369 -228.070008 1.363927e-02  42.554 6.80712e-06 3.66008e-02
+       1184    32 -228.056400 -228.069915 1.351502e-02  42.554 6.68216e-06 3.65347e-02
+       1185    32 -228.056431 -228.069825 1.339304e-02  42.554 6.56061e-06 3.64691e-02
+       1186    32 -228.056463 -228.069735 1.327273e-02  42.554 6.44201e-06 3.64039e-02
+       1187    32 -228.056494 -228.069647 1.315350e-02  42.554 6.32613e-06 3.63392e-02
+       1188    32 -228.056525 -228.069560 1.303481e-02  42.554 6.21301e-06 3.62749e-02
+       1189    32 -228.056556 -228.069472 1.291625e-02  42.554 6.10290e-06 3.62110e-02
+       1190    32 -228.056586 -228.069384 1.279757e-02  42.554 5.99605e-06 3.61475e-02
+       1191    32 -228.056617 -228.069296 1.267868e-02  42.554 5.89247e-06 3.60844e-02
+       1192    32 -228.056647 -228.069207 1.255965e-02  42.554 5.79175e-06 3.60218e-02
+       1193    32 -228.056678 -228.069119 1.244064e-02  42.554 5.69299e-06 3.59595e-02
+       1194    32 -228.056708 -228.069030 1.232192e-02  42.554 5.59504e-06 3.58976e-02
+       1195    32 -228.056738 -228.068942 1.220376e-02  42.554 5.49674e-06 3.58361e-02
+       1196    32 -228.056769 -228.068855 1.208646e-02  42.554 5.39726e-06 3.57749e-02
+       1197    32 -228.056799 -228.068769 1.197028e-02  42.554 5.29632e-06 3.57141e-02
+       1198    32 -228.056829 -228.068684 1.185541e-02  42.554 5.19422e-06 3.56537e-02
+       1199    32 -228.056858 -228.068600 1.174199e-02  42.554 5.09177e-06 3.55936e-02
+       1200    32 -228.056888 -228.068518 1.163007e-02  42.554 4.99006e-06 3.55338e-02
+       1201    32 -228.056918 -228.068437 1.151963e-02  42.554 4.89031e-06 3.54744e-02
+       1202    32 -228.056947 -228.068358 1.141060e-02  42.554 4.79362e-06 3.54153e-02
+       1203    32 -228.056977 -228.068279 1.130286e-02  42.554 4.70094e-06 3.53566e-02
+       1204    32 -228.057006 -228.068202 1.119626e-02  42.554 4.61305e-06 3.52981e-02
+       1205    32 -228.057035 -228.068126 1.109063e-02  42.554 4.53055e-06 3.52400e-02
+       1206    32 -228.057064 -228.068050 1.098583e-02  42.554 4.45398e-06 3.51822e-02
+       1207    32 -228.057093 -228.067975 1.088174e-02  42.554 4.38385e-06 3.51246e-02
+       1208    32 -228.057122 -228.067901 1.077826e-02  42.554 4.32067e-06 3.50674e-02
+       1209    32 -228.057151 -228.067826 1.067534e-02  42.554 4.26495e-06 3.50105e-02
+       1210    32 -228.057180 -228.067753 1.057296e-02  42.554 4.21720e-06 3.49538e-02
+       1211    32 -228.057209 -228.067680 1.047114e-02  42.554 4.17789e-06 3.48975e-02
+       1212    32 -228.057237 -228.067607 1.036992e-02  42.554 4.14745e-06 3.48414e-02
+       1213    32 -228.057266 -228.067535 1.026937e-02  42.554 4.12621e-06 3.47856e-02
+       1214    32 -228.057294 -228.067463 1.016953e-02  42.554 4.11449e-06 3.47301e-02
+       1215    32 -228.057322 -228.067393 1.007046e-02  42.554 4.11261e-06 3.46748e-02
+       1216    32 -228.057350 -228.067323 9.972204e-03  42.554 4.12098e-06 3.46198e-02
+       1217    32 -228.057379 -228.067253 9.874785e-03  42.554 4.14017e-06 3.45650e-02
+       1218    32 -228.057407 -228.067185 9.778212e-03  42.554 4.17102e-06 3.45105e-02
+       1219    32 -228.057435 -228.067117 9.682483e-03  42.554 4.21466e-06 3.44562e-02
+       1220    32 -228.057462 -228.067050 9.587585e-03  42.554 4.27260e-06 3.44022e-02
+       1221    32 -228.057490 -228.066984 9.493503e-03  42.554 4.34675e-06 3.43484e-02
+       1222    32 -228.057518 -228.066918 9.400223e-03  42.554 4.43942e-06 3.42949e-02
+       1223    32 -228.057545 -228.066853 9.308090e-03  42.554 4.75973e-06 3.42415e-02
+       1224    32 -228.057572 -228.066829 9.257452e-03  42.554 7.16253e-06 3.41880e-02
+       1225    32 -228.057598 -228.066829 9.230576e-03  42.554 1.45841e-05 3.41334e-02
+       1226    31 -228.057623 -228.066885 9.262323e-03  42.554 2.81063e-05 3.40762e-02
+       1227    31 -228.057648 -228.067142 9.493918e-03  42.554 4.27121e-05 3.40166e-02
+       1228    31 -228.057673 -228.067496 9.823356e-03  42.554 5.49063e-05 3.39569e-02
+       1229    31 -228.057698 -228.067823 1.012496e-02  42.554 6.33410e-05 3.38987e-02
+       1230    31 -228.057724 -228.068096 1.037190e-02  42.554 6.68821e-05 3.38423e-02
+       1231    29 -228.057751 -228.068304 1.055319e-02  42.554 6.54939e-05 3.37878e-02
+       1232    30 -228.057778 -228.068432 1.065348e-02  42.554 5.97319e-05 3.37345e-02
+       1233    30 -228.057805 -228.068455 1.064934e-02  42.554 5.31434e-05 3.36817e-02
+       1234    31 -228.057833 -228.068416 1.058299e-02  42.554 4.67549e-05 3.36285e-02
+       1235    29 -228.057861 -228.068299 1.043834e-02  42.554 3.98686e-05 3.35747e-02
+       1236    31 -228.057889 -228.068078 1.018940e-02  42.554 3.32776e-05 3.35208e-02
+       1237    30 -228.057916 -228.067801 9.884403e-03  42.554 2.75997e-05 3.34671e-02
+       1238    31 -228.057944 -228.067529 9.584517e-03  42.554 2.29274e-05 3.34142e-02
+       1239    31 -228.057971 -228.067303 9.331971e-03  42.554 1.90167e-05 3.33622e-02
+       1240    32 -228.057999 -228.067143 9.144435e-03  42.554 1.52481e-05 3.33113e-02
+       1241    31 -228.058026 -228.067185 9.159120e-03  42.554 1.14414e-05 3.32601e-02
+       1242    32 -228.058053 -228.067238 9.185221e-03  42.554 9.81978e-06 3.32087e-02
+       1243    32 -228.058079 -228.067241 9.161947e-03  42.554 1.02916e-05 3.31569e-02
+       1244    32 -228.058105 -228.067210 9.104265e-03  42.554 1.14004e-05 3.31051e-02
+       1245    32 -228.058131 -228.067130 8.998682e-03  42.554 1.22401e-05 3.30536e-02
+       1246    32 -228.058157 -228.067014 8.856803e-03  42.554 1.25979e-05 3.30022e-02
+       1247    31 -228.058182 -228.066879 8.697167e-03  42.554 1.24697e-05 3.29509e-02
+       1248    32 -228.058208 -228.066785 8.577838e-03  42.554 1.23323e-05 3.28997e-02
+       1249    30 -228.058233 -228.066784 8.550999e-03  42.554 1.23565e-05 3.28488e-02
+       1250    32 -228.058259 -228.066790 8.531679e-03  42.554 1.21982e-05 3.27986e-02
+       1251    30 -228.058284 -228.066796 8.512204e-03  42.554 1.16751e-05 3.27489e-02
+       1252    32 -228.058309 -228.066803 8.493872e-03  42.554 1.08504e-05 3.26996e-02
+       1253    30 -228.058334 -228.066807 8.473043e-03  42.554 9.95270e-06 3.26508e-02
+       1254    32 -228.058359 -228.066797 8.438206e-03  42.554 9.09471e-06 3.26021e-02
+       1255    31 -228.058383 -228.066762 8.378530e-03  42.554 8.23640e-06 3.25535e-02
+       1256    32 -228.058408 -228.066698 8.290647e-03  42.554 7.31588e-06 3.25050e-02
+       1257    30 -228.058432 -228.066611 8.179195e-03  42.554 6.43543e-06 3.24566e-02
+       1258    32 -228.058456 -228.066510 8.054277e-03  42.554 6.02412e-06 3.24082e-02
+       1259    31 -228.058480 -228.066415 7.934209e-03  42.554 6.95358e-06 3.23599e-02
+       1260    32 -228.058504 -228.066307 7.802585e-03  42.554 9.03564e-06 3.23116e-02
+       1261    32 -228.058528 -228.066224 7.695899e-03  42.554 1.17970e-05 3.22636e-02
+       1262    32 -228.058552 -228.066163 7.611106e-03  42.554 1.45519e-05 3.22156e-02
+       1263    31 -228.058576 -228.066119 7.542678e-03  42.554 1.68793e-05 3.21678e-02
+       1264    31 -228.058600 -228.066088 7.488109e-03  42.554 1.84973e-05 3.21202e-02
+       1265    31 -228.058624 -228.066065 7.441638e-03  42.554 1.92744e-05 3.20727e-02
+       1266    31 -228.058648 -228.066046 7.397653e-03  42.554 1.91922e-05 3.20254e-02
+       1267    31 -228.058672 -228.066023 7.350747e-03  42.554 1.83321e-05 3.19782e-02
+       1268    31 -228.058696 -228.065994 7.297926e-03  42.554 1.68330e-05 3.19312e-02
+       1269    31 -228.058721 -228.065959 7.238518e-03  42.554 1.48635e-05 3.18843e-02
+       1270    31 -228.058745 -228.065918 7.173602e-03  42.554 1.26001e-05 3.18375e-02
+       1271    31 -228.058769 -228.065874 7.104781e-03  42.554 1.02278e-05 3.17908e-02
+       1272    31 -228.058793 -228.065827 7.033400e-03  42.554 7.95970e-06 3.17442e-02
+       1273    32 -228.058818 -228.065778 6.960101e-03  42.554 6.08040e-06 3.16978e-02
+       1274    32 -228.058842 -228.065727 6.885058e-03  42.554 4.96830e-06 3.16514e-02
+       1275    32 -228.058866 -228.065674 6.808145e-03  42.554 4.84382e-06 3.16052e-02
+       1276    32 -228.058889 -228.065619 6.729470e-03  42.554 5.37102e-06 3.15591e-02
+       1277    32 -228.058913 -228.065562 6.649545e-03  42.554 6.00589e-06 3.15132e-02
+       1278    32 -228.058936 -228.065506 6.569384e-03  42.554 6.41837e-06 3.14675e-02
+       1279    32 -228.058960 -228.065450 6.490343e-03  42.554 6.47885e-06 3.14220e-02
+       1280    32 -228.058983 -228.065397 6.413817e-03  42.554 6.17702e-06 3.13767e-02
+       1281    32 -228.059006 -228.065347 6.340899e-03  42.554 5.58388e-06 3.13315e-02
+       1282    32 -228.059028 -228.065301 6.272165e-03  42.554 4.84295e-06 3.12865e-02
+       1283    32 -228.059051 -228.065259 6.207540e-03  42.554 4.17984e-06 3.12417e-02
+       1284    32 -228.059074 -228.065220 6.146350e-03  42.554 3.88290e-06 3.11970e-02
+       1285    32 -228.059096 -228.065184 6.087495e-03  42.554 4.13196e-06 3.11524e-02
+       1286    32 -228.059119 -228.065148 6.029665e-03  42.554 4.81432e-06 3.11079e-02
+       1287    32 -228.059141 -228.065113 5.971580e-03  42.554 5.68039e-06 3.10635e-02
+       1288    32 -228.059164 -228.065076 5.912188e-03  42.554 6.53886e-06 3.10193e-02
+       1289    32 -228.059186 -228.065037 5.850801e-03  42.554 7.27957e-06 3.09751e-02
+       1290    32 -228.059208 -228.064995 5.787145e-03  42.554 7.84546e-06 3.09311e-02
+       1291    32 -228.059231 -228.064952 5.721349e-03  42.554 8.21165e-06 3.08872e-02
+       1292    31 -228.059253 -228.064907 5.653867e-03  42.554 8.37368e-06 3.08434e-02
+       1293    31 -228.059275 -228.064861 5.585319e-03  42.554 8.34042e-06 3.07997e-02
+       1294    31 -228.059298 -228.064814 5.516468e-03  42.554 8.13081e-06 3.07562e-02
+       1295    31 -228.059320 -228.064768 5.448008e-03  42.554 7.77076e-06 3.07128e-02
+       1296    31 -228.059342 -228.064723 5.380526e-03  42.554 7.29174e-06 3.06695e-02
+       1297    31 -228.059364 -228.064679 5.314430e-03  42.554 6.72958e-06 3.06263e-02
+       1298    32 -228.059386 -228.064636 5.249908e-03  42.554 6.12306e-06 3.05832e-02
+       1299    32 -228.059408 -228.064596 5.187017e-03  42.554 5.51281e-06 3.05403e-02
+       1300    32 -228.059431 -228.064556 5.125566e-03  42.554 4.93824e-06 3.04974e-02
+       1301    32 -228.059452 -228.064518 5.065294e-03  42.554 4.43422e-06 3.04547e-02
+       1302    32 -228.059474 -228.064480 5.005848e-03  42.554 4.02563e-06 3.04121e-02
+       1303    32 -228.059496 -228.064443 4.946860e-03  42.554 3.72149e-06 3.03696e-02
+       1304    32 -228.059518 -228.064406 4.887979e-03  42.554 3.51275e-06 3.03272e-02
+       1305    32 -228.059540 -228.064368 4.828910e-03  42.554 3.37657e-06 3.02850e-02
+       1306    32 -228.059561 -228.064330 4.769439e-03  42.554 3.28637e-06 3.02428e-02
+       1307    32 -228.059583 -228.064292 4.709447e-03  42.554 3.22228e-06 3.02008e-02
+       1308    32 -228.059604 -228.064253 4.648916e-03  42.554 3.17735e-06 3.01590e-02
+       1309    32 -228.059625 -228.064213 4.587920e-03  42.554 3.15851e-06 3.01172e-02
+       1310    32 -228.059646 -228.064173 4.526613e-03  42.554 3.18269e-06 3.00756e-02
+       1311    32 -228.059668 -228.064133 4.465203e-03  42.554 3.26868e-06 3.00341e-02
+       1312    32 -228.059689 -228.064093 4.403932e-03  42.554 3.42733e-06 2.99926e-02
+       1313    32 -228.059710 -228.064053 4.343038e-03  42.554 3.65486e-06 2.99513e-02
+       1314    32 -228.059731 -228.064013 4.282732e-03  42.554 3.93290e-06 2.99102e-02
+       1315    32 -228.059751 -228.063975 4.223172e-03  42.554 4.23381e-06 2.98691e-02
+       1316    32 -228.059772 -228.063937 4.164452e-03  42.554 4.52732e-06 2.98281e-02
+       1317    32 -228.059793 -228.063900 4.106592e-03  42.554 4.78553e-06 2.97872e-02
+       1318    32 -228.059814 -228.063863 4.049542e-03  42.554 4.98597e-06 2.97465e-02
+       1319    32 -228.059835 -228.063828 3.993197e-03  42.554 5.11315e-06 2.97058e-02
+       1320    32 -228.059855 -228.063793 3.937414e-03  42.554 5.15612e-06 2.96652e-02
+       1321    32 -228.059876 -228.063760 3.884246e-03  42.554 5.09976e-06 2.96248e-02
+       1322    32 -228.059897 -228.063731 3.834139e-03  42.554 4.94516e-06 2.95844e-02
+       1323    32 -228.059917 -228.063697 3.779440e-03  42.554 4.73886e-06 2.95442e-02
+       1324    32 -228.059938 -228.063666 3.728704e-03  42.554 4.46214e-06 2.95040e-02
+       1325    32 -228.059958 -228.063635 3.677328e-03  42.554 4.16056e-06 2.94640e-02
+       1326    32 -228.059979 -228.063602 3.623161e-03  42.554 3.86129e-06 2.94240e-02
+       1327    32 -228.059999 -228.063566 3.567203e-03  42.554 3.58881e-06 2.93842e-02
+       1328    32 -228.060019 -228.063529 3.509386e-03  42.554 3.36365e-06 2.93445e-02
+       1329    32 -228.060039 -228.063490 3.450204e-03  42.554 3.19338e-06 2.93048e-02
+       1330    32 -228.060060 -228.063450 3.390273e-03  42.554 3.07567e-06 2.92653e-02
+       1331    32 -228.060080 -228.063410 3.330287e-03  42.554 3.00291e-06 2.92258e-02
+       1332    32 -228.060100 -228.063371 3.270948e-03  42.554 2.96832e-06 2.91865e-02
+       1333    32 -228.060120 -228.063333 3.212866e-03  42.554 2.97052e-06 2.91472e-02
+       1334    32 -228.060140 -228.063296 3.156470e-03  42.554 3.01321e-06 2.91081e-02
+       1335    32 -228.060160 -228.063262 3.101975e-03  42.554 3.10004e-06 2.90691e-02
+       1336    32 -228.060179 -228.063229 3.049400e-03  42.554 3.22897e-06 2.90301e-02
+       1337    32 -228.060199 -228.063198 2.998614e-03  42.554 3.38953e-06 2.89913e-02
+       1338    32 -228.060219 -228.063168 2.949376e-03  42.554 3.56434e-06 2.89525e-02
+       1339    32 -228.060238 -228.063140 2.901375e-03  42.554 3.73296e-06 2.89139e-02
+       1340    32 -228.060258 -228.063112 2.854258e-03  42.554 3.87596e-06 2.88753e-02
+       1341    32 -228.060277 -228.063085 2.807667e-03  42.554 3.97769e-06 2.88368e-02
+       1342    32 -228.060297 -228.063058 2.761261e-03  42.554 4.02800e-06 2.87984e-02
+       1343    32 -228.060316 -228.063031 2.714734e-03  42.554 4.02292e-06 2.87602e-02
+       1344    32 -228.060336 -228.063004 2.667827e-03  42.554 3.96482e-06 2.87220e-02
+       1345    32 -228.060355 -228.062975 2.620323e-03  42.554 3.86193e-06 2.86839e-02
+       1346    32 -228.060374 -228.062946 2.572059e-03  42.554 3.72726e-06 2.86458e-02
+       1347    32 -228.060394 -228.062917 2.522933e-03  42.554 3.57688e-06 2.86079e-02
+       1348    32 -228.060413 -228.062886 2.472935e-03  42.554 3.42737e-06 2.85701e-02
+       1349    32 -228.060432 -228.062854 2.422163e-03  42.554 3.29317e-06 2.85323e-02
+       1350    32 -228.060451 -228.062822 2.370838e-03  42.554 3.18428e-06 2.84946e-02
+       1351    32 -228.060470 -228.062790 2.319287e-03  42.554 3.10558e-06 2.84571e-02
+       1352    32 -228.060489 -228.062757 2.267907e-03  42.554 3.05769e-06 2.84196e-02
+       1353    32 -228.060508 -228.062725 2.217104e-03  42.554 3.03884e-06 2.83822e-02
+       1354    32 -228.060527 -228.062694 2.167240e-03  42.554 3.04634e-06 2.83449e-02
+       1355    32 -228.060546 -228.062665 2.118582e-03  42.554 3.07687e-06 2.83076e-02
+       1356    32 -228.060565 -228.062636 2.071268e-03  42.554 3.12579e-06 2.82705e-02
+       1357    32 -228.060583 -228.062609 2.025309e-03  42.554 3.18637e-06 2.82334e-02
+       1358    32 -228.060602 -228.062583 1.980590e-03  42.554 3.24985e-06 2.81965e-02
+       1359    32 -228.060621 -228.062558 1.936899e-03  42.554 3.30649e-06 2.81596e-02
+       1360    32 -228.060639 -228.062533 1.893943e-03  42.554 3.34730e-06 2.81228e-02
+       1361    32 -228.060658 -228.062509 1.851392e-03  42.554 3.36590e-06 2.80860e-02
+       1362    32 -228.060676 -228.062485 1.808913e-03  42.554 3.35974e-06 2.80494e-02
+       1363    32 -228.060695 -228.062461 1.766232e-03  42.554 3.33022e-06 2.80128e-02
+       1364    32 -228.060713 -228.062436 1.723179e-03  42.554 3.28185e-06 2.79764e-02
+       1365    32 -228.060732 -228.062411 1.679723e-03  42.554 3.22069e-06 2.79400e-02
+       1366    32 -228.060750 -228.062386 1.635964e-03  42.554 3.15284e-06 2.79036e-02
+       1367    32 -228.060768 -228.062360 1.592086e-03  42.554 3.08345e-06 2.78674e-02
+       1368    32 -228.060787 -228.062335 1.548296e-03  42.554 3.01636e-06 2.78312e-02
+       1369    32 -228.060805 -228.062309 1.504762e-03  42.554 2.95431e-06 2.77952e-02
+       1370    32 -228.060823 -228.062284 1.461574e-03  42.554 2.89920e-06 2.77591e-02
+       1371    32 -228.060841 -228.062260 1.418741e-03  42.554 2.85243e-06 2.77232e-02
+       1372    32 -228.060859 -228.062235 1.376214e-03  42.554 2.81492e-06 2.76874e-02
+       1373    32 -228.060877 -228.062211 1.333938e-03  42.554 2.78699e-06 2.76516e-02
+       1374    32 -228.060895 -228.062187 1.292021e-03  42.554 2.76619e-06 2.76159e-02
+       1375    32 -228.060913 -228.062165 1.252484e-03  42.554 2.74943e-06 2.75803e-02
+       1376    32 -228.060931 -228.062141 1.210697e-03  42.554 2.74759e-06 2.75447e-02
+       1377    32 -228.060948 -228.062118 1.169500e-03  42.554 2.74867e-06 2.75093e-02
+       1378    32 -228.060966 -228.062094 1.128067e-03  42.554 2.75716e-06 2.74739e-02
+       1379    32 -228.060984 -228.062071 1.087192e-03  42.554 2.76816e-06 2.74386e-02
+       1380    32 -228.061002 -228.062048 1.046700e-03  42.554 2.78204e-06 2.74033e-02
+       1381    32 -228.061019 -228.062026 1.006739e-03  42.554 2.79734e-06 2.73681e-02
+       1382    32 -228.061037 -228.062004 9.673073e-04  42.554 2.81318e-06 2.73330e-02
+       1383    32 -228.061054 -228.061983 9.284845e-04  42.554 2.82781e-06 2.72980e-02
+       1384    32 -228.061072 -228.061962 8.902277e-04  42.554 2.83935e-06 2.72631e-02
+       1385    32 -228.061089 -228.061942 8.523945e-04  42.554 2.84611e-06 2.72282e-02
+       1386    32 -228.061107 -228.061921 8.147710e-04  42.554 2.84737e-06 2.71934e-02
+       1387    32 -228.061124 -228.061901 7.771677e-04  42.554 2.84353e-06 2.71586e-02
+       1388    32 -228.061141 -228.061881 7.394751e-04  42.554 2.83589e-06 2.71239e-02
+       1389    32 -228.061158 -228.061860 7.016767e-04  42.554 2.82620e-06 2.70893e-02
+       1390    32 -228.061176 -228.061840 6.638278e-04  42.554 2.81620e-06 2.70548e-02
+       1391    32 -228.061193 -228.061819 6.260240e-04  42.554 2.80731e-06 2.70203e-02
+       1392    32 -228.061210 -228.061798 5.883835e-04  42.554 2.80053e-06 2.69859e-02
+       1393    32 -228.061227 -228.061778 5.510277e-04  42.554 2.79646e-06 2.69516e-02
+       1394    32 -228.061244 -228.061758 5.140699e-04  42.554 2.79527e-06 2.69174e-02
+       1395    32 -228.061261 -228.061739 4.775972e-04  42.554 2.79675e-06 2.68832e-02
+       1396    32 -228.061278 -228.061720 4.417179e-04  42.554 2.80018e-06 2.68491e-02
+       1397    32 -228.061295 -228.061701 4.065290e-04  42.554 2.80470e-06 2.68150e-02
+       1398    32 -228.061312 -228.061684 3.717828e-04  42.554 2.80993e-06 2.67810e-02
+       1399    32 -228.061329 -228.061666 3.373936e-04  42.554 2.81499e-06 2.67471e-02
+       1400    32 -228.061345 -228.061649 3.032362e-04  42.554 2.81954e-06 2.67132e-02
+       1401    32 -228.061362 -228.061631 2.692224e-04  42.554 2.82334e-06 2.66795e-02
+       1402    32 -228.061379 -228.061614 2.352718e-04  42.554 2.82654e-06 2.66457e-02
+       1403    32 -228.061395 -228.061597 2.013444e-04  42.554 2.82949e-06 2.66121e-02
+       1404    32 -228.061412 -228.061580 1.674446e-04  42.554 2.83268e-06 2.65785e-02
+       1405    32 -228.061429 -228.061562 1.336187e-04  42.554 2.83656e-06 2.65450e-02
+       1406    32 -228.061445 -228.061545 9.993450e-05  42.554 2.84144e-06 2.65115e-02
+       1407    32 -228.061462 -228.061528 6.645966e-05  42.554 2.84741e-06 2.64781e-02
+       1408    32 -228.061478 -228.061511 3.324780e-05  42.554 2.85443e-06 2.64448e-02
+       1409    32 -228.061495 -228.061495 3.337280e-07  42.554 2.86228e-06 2.64115e-02
+       1410    32 -228.061511 -228.061479 3.226579e-05  42.554 2.87069e-06 2.63783e-02
+       1411    32 -228.061527 -228.061463 6.454972e-05  42.554 2.87931e-06 2.63452e-02
+       1412    32 -228.061543 -228.061447 9.653115e-05  42.554 2.88782e-06 2.63121e-02
+       1413    32 -228.061560 -228.061431 1.282339e-04  42.554 2.89591e-06 2.62791e-02
+       1414    32 -228.061576 -228.061416 1.596877e-04  42.554 2.90335e-06 2.62461e-02
+       1415    32 -228.061592 -228.061401 1.909221e-04  42.554 2.91000e-06 2.62132e-02
+       1416    32 -228.061608 -228.061386 2.219601e-04  42.554 2.91579e-06 2.61804e-02
+       1417    32 -228.061624 -228.061371 2.528157e-04  42.554 2.92073e-06 2.61476e-02
+       1418    32 -228.061640 -228.061357 2.834923e-04  42.554 2.92486e-06 2.61149e-02
+       1419    32 -228.061656 -228.061342 3.139856e-04  42.554 2.92828e-06 2.60823e-02
+       1420    32 -228.061672 -228.061328 3.442868e-04  42.554 2.93109e-06 2.60497e-02
+       1421    32 -228.061688 -228.061314 3.743854e-04  42.554 2.93342e-06 2.60171e-02
+       1422    32 -228.061704 -228.061300 4.042712e-04  42.554 2.93541e-06 2.59847e-02
+       1423    32 -228.061720 -228.061286 4.339400e-04  42.554 2.93716e-06 2.59523e-02
+       1424    32 -228.061736 -228.061272 4.633866e-04  42.554 2.93886e-06 2.59199e-02
+       1425    32 -228.061751 -228.061259 4.926124e-04  42.554 2.94084e-06 2.58876e-02
+       1426    32 -228.061767 -228.061246 5.212673e-04  42.554 4.17543e-06 2.58474e-02
+       1427    32 -228.061780 -228.061453 3.270668e-04  42.554 2.60311e-05 2.57794e-02
+       1428    32 -228.061798 -228.063330 1.532673e-03  42.554 2.99605e-05 2.57217e-02
+       1429    32 -228.061816 -228.064363 2.546846e-03  42.554 3.30446e-05 2.56725e-02
+       1430    32 -228.061835 -228.064706 2.871105e-03  42.554 3.60787e-05 2.56390e-02
+       1431    32 -228.061852 -228.064467 2.614308e-03  42.554 3.56906e-05 2.56098e-02
+       1432    32 -228.061868 -228.064113 2.245167e-03  42.554 3.05850e-05 2.55784e-02
+       1433    32 -228.061882 -228.063927 2.045387e-03  42.554 2.35675e-05 2.55437e-02
+       1434    32 -228.061895 -228.064071 2.175361e-03  42.554 1.80379e-05 2.55073e-02
+       1435    32 -228.061908 -228.064278 2.369495e-03  42.554 1.36624e-05 2.54730e-02
+       1436    32 -228.061922 -228.064442 2.520666e-03  42.554 1.02200e-05 2.54408e-02
+       1437    32 -228.061935 -228.064433 2.498074e-03  42.554 9.23831e-06 2.54084e-02
+       1438    32 -228.061948 -228.064260 2.311941e-03  42.554 1.24919e-05 2.53741e-02
+       1439    32 -228.061962 -228.063986 2.024574e-03  42.554 1.73851e-05 2.53382e-02
+       1440    32 -228.061976 -228.063760 1.784094e-03  42.554 2.10645e-05 2.53026e-02
+       1441    32 -228.061991 -228.063585 1.594344e-03  42.554 2.28957e-05 2.52688e-02
+       1442    31 -228.062007 -228.063488 1.480950e-03  42.554 2.23445e-05 2.52369e-02
+       1443    31 -228.062023 -228.063463 1.440690e-03  42.554 1.95379e-05 2.52055e-02
+       1444    30 -228.062039 -228.063504 1.465169e-03  42.554 1.49003e-05 2.51738e-02
+       1445    29 -228.062056 -228.063589 1.533835e-03  42.554 9.32181e-06 2.51413e-02
+       1446    31 -228.062072 -228.063695 1.623545e-03  42.554 5.36052e-06 2.51083e-02
+       1447    32 -228.062088 -228.063801 1.713245e-03  42.554 7.90826e-06 2.50753e-02
+       1448    31 -228.062104 -228.063891 1.787714e-03  42.554 1.26141e-05 2.50424e-02
+       1449    32 -228.062119 -228.063956 1.837211e-03  42.554 1.61737e-05 2.50097e-02
+       1450    31 -228.062134 -228.063990 1.856591e-03  42.554 1.77696e-05 2.49771e-02
+       1451    31 -228.062148 -228.063993 1.845280e-03  42.554 1.72142e-05 2.49448e-02
+       1452    31 -228.062162 -228.063970 1.808286e-03  42.554 1.46961e-05 2.49129e-02
+       1453    31 -228.062176 -228.063932 1.756332e-03  42.554 1.07271e-05 2.48812e-02
+       1454    32 -228.062189 -228.063892 1.703223e-03  42.554 6.26601e-06 2.48496e-02
+       1455    32 -228.062203 -228.063865 1.661836e-03  42.554 4.08904e-06 2.48179e-02
+       1456    32 -228.062216 -228.063856 1.639325e-03  42.554 6.82896e-06 2.47858e-02
+       1457    32 -228.062230 -228.063866 1.635565e-03  42.554 1.01857e-05 2.47536e-02
+       1458    31 -228.062244 -228.063887 1.643604e-03  42.554 1.24310e-05 2.47214e-02
+       1459    31 -228.062258 -228.063911 1.653044e-03  42.554 1.32099e-05 2.46893e-02
+       1460    31 -228.062272 -228.063926 1.653599e-03  42.554 1.25537e-05 2.46576e-02
+       1461    30 -228.062287 -228.063925 1.638169e-03  42.554 1.07163e-05 2.46260e-02
+       1462    30 -228.062301 -228.063906 1.604872e-03  42.554 8.10639e-06 2.45946e-02
+       1463    30 -228.062316 -228.063872 1.556066e-03  42.554 5.29086e-06 2.45633e-02
+       1464    29 -228.062331 -228.063829 1.498106e-03  42.554 3.30852e-06 2.45319e-02
+       1465    32 -228.062346 -228.063785 1.439106e-03  42.554 3.69078e-06 2.45006e-02
+       1466    31 -228.062360 -228.063748 1.387407e-03  42.554 5.26246e-06 2.44691e-02
+       1467    32 -228.062375 -228.063725 1.349865e-03  42.554 6.52548e-06 2.44377e-02
+       1468    30 -228.062389 -228.063720 1.330663e-03  42.554 7.09094e-06 2.44064e-02
+       1469    32 -228.062403 -228.063734 1.330715e-03  42.554 6.92839e-06 2.43751e-02
+       1470    31 -228.062417 -228.063765 1.347689e-03  42.554 6.16773e-06 2.43440e-02
+       1471    32 -228.062431 -228.063807 1.376478e-03  42.554 5.05487e-06 2.43129e-02
+       1472    30 -228.062444 -228.063855 1.410403e-03  42.554 3.95991e-06 2.42820e-02
+       1473    32 -228.062458 -228.063900 1.442306e-03  42.554 3.37906e-06 2.42510e-02
+       1474    32 -228.062471 -228.063937 1.465909e-03  42.554 3.58963e-06 2.42201e-02
+       1475    32 -228.062484 -228.063961 1.476655e-03  42.554 4.23950e-06 2.41892e-02
+       1476    31 -228.062498 -228.063970 1.472219e-03  42.554 4.86730e-06 2.41583e-02
+       1477    31 -228.062511 -228.063964 1.452727e-03  42.554 5.24360e-06 2.41275e-02
+       1478    31 -228.062525 -228.063945 1.420397e-03  42.554 5.29914e-06 2.40966e-02
+       1479    31 -228.062538 -228.063917 1.378964e-03  42.554 5.05137e-06 2.40659e-02
+       1480    32 -228.062552 -228.063885 1.332954e-03  42.554 4.56860e-06 2.40352e-02
+       1481    31 -228.062566 -228.063853 1.286876e-03  42.554 3.95371e-06 2.40046e-02
+       1482    31 -228.062580 -228.063824 1.244804e-03  42.554 3.33665e-06 2.39740e-02
+       1483    32 -228.062593 -228.063803 1.209728e-03  42.554 2.86321e-06 2.39436e-02
+       1484    31 -228.062607 -228.063790 1.183451e-03  42.554 2.64878e-06 2.39131e-02
+       1485    32 -228.062621 -228.063787 1.166564e-03  42.554 2.69085e-06 2.38827e-02
+       1486    32 -228.062634 -228.063793 1.158522e-03  42.554 2.86808e-06 2.38524e-02
+       1487    32 -228.062648 -228.063806 1.157933e-03  42.554 3.04925e-06 2.38221e-02
+       1488    32 -228.062661 -228.063824 1.162805e-03  42.554 3.15786e-06 2.37918e-02
+       1489    32 -228.062674 -228.063845 1.170908e-03  42.554 3.17170e-06 2.37616e-02
+       1490    32 -228.062688 -228.063867 1.179947e-03  42.554 3.10733e-06 2.37314e-02
+       1491    32 -228.062701 -228.063889 1.187856e-03  42.554 3.00545e-06 2.37013e-02
+       1492    32 -228.062714 -228.063907 1.192910e-03  42.554 2.91596e-06 2.36713e-02
+       1493    32 -228.062727 -228.063921 1.193868e-03  42.554 2.87927e-06 2.36412e-02
+       1494    32 -228.062740 -228.063930 1.189976e-03  42.554 2.90888e-06 2.36113e-02
+       1495    32 -228.062753 -228.063934 1.181027e-03  42.554 2.98722e-06 2.35813e-02
+       1496    32 -228.062766 -228.063933 1.167296e-03  42.554 3.07826e-06 2.35514e-02
+       1497    32 -228.062778 -228.063928 1.149490e-03  42.554 3.14565e-06 2.35216e-02
+       1498    31 -228.062791 -228.063920 1.128647e-03  42.554 3.16471e-06 2.34917e-02
+       1499    31 -228.062804 -228.063910 1.106024e-03  42.554 3.12676e-06 2.34620e-02
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization did not converge in  20 iterations 
+            Total energy change: -2.904250e-02
+            Final gradient norm: 5.413502e-06
+
+       1500    31 -228.091860 -228.234745 1.428856e-01   0.006 3.03835e-06 2.34323e-02
+       1501    41 -221.411097 -228.072387 6.661290e+00   0.006 3.61911e+01 1.09666e-01
+       1502    22 -227.617427 -228.498237 8.808097e-01   0.006 2.38292e+01 5.54047e-02
+       1503    22 -227.270813 -228.621080 1.350267e+00   0.006 8.44295e+00 4.88751e-02
+       1504    19 -228.743965 -228.613718 1.302467e-01   0.006 7.96480e+00 3.70431e-02
+       1505    20 -229.695337 -228.533486 1.161852e+00   0.006 7.88155e+00 2.06763e-02
+       1506    23 -229.832151 -228.461164 1.370987e+00   0.006 8.16894e+00 7.07835e-03
+       1507    26 -229.230538 -228.400044 8.304945e-01   0.006 5.37486e+00 7.28584e-03
+       1508    23 -228.981149 -228.367862 6.132861e-01   0.006 3.54257e+00 8.45693e-03
+       1509    23 -228.769513 -228.357956 4.115573e-01   0.006 2.10203e+00 9.15639e-03
+       1510    19 -228.545916 -228.355476 1.904398e-01   0.006 1.63647e+00 8.84404e-03
+       1511    23 -228.251340 -228.365595 1.142547e-01   0.006 2.14942e+00 6.70663e-03
+       1512    24 -228.093028 -228.386568 2.935399e-01   0.006 2.68669e+00 3.89998e-03
+       1513    25 -228.050234 -228.410671 3.604376e-01   0.006 2.59524e+00 2.32422e-03
+       1514    28 -228.134308 -228.430551 2.962430e-01   0.006 1.88094e+00 3.60004e-03
+       1515    22 -228.286898 -228.441193 1.542957e-01   0.006 9.25013e-01 4.70865e-03
+       1516    22 -228.434473 -228.441151 6.678195e-03   0.006 7.16321e-01 4.66490e-03
+       1517    23 -228.549943 -228.432364 1.175789e-01   0.006 1.32543e+00 3.60674e-03
+       1518    24 -228.606083 -228.418677 1.874060e-01   0.006 1.67294e+00 1.98226e-03
+       1519    25 -228.609662 -228.404035 2.056270e-01   0.006 1.62292e+00 9.15965e-04
+       1520    28 -228.570603 -228.392121 1.784825e-01   0.006 1.25123e+00 1.90703e-03
+       1521    22 -228.507350 -228.385543 1.218072e-01   0.006 7.55124e-01 2.53218e-03
+       1522    23 -228.432935 -228.383763 4.917174e-02   0.006 4.77037e-01 2.63569e-03
+       1523    23 -228.373395 -228.386430 1.303540e-02   0.006 6.80972e-01 2.14795e-03
+       1524    24 -228.332622 -228.392100 5.947717e-02   0.006 8.82360e-01 1.31020e-03
+       1525    25 -228.319789 -228.398843 7.905406e-02   0.006 8.87530e-01 6.32567e-04
+       1526    28 -228.331166 -228.404752 7.358521e-02   0.006 7.12907e-01 9.71463e-04
+       1527    24 -228.362541 -228.408401 4.585963e-02   0.006 4.53834e-01 1.43628e-03
+       1528    24 -228.396485 -228.409094 1.260882e-02   0.006 3.20381e-01 1.55047e-03
+       1529    24 -228.427398 -228.407130 2.026836e-02   0.006 4.39611e-01 1.30318e-03
+       1530    24 -228.447349 -228.403371 4.397821e-02   0.006 5.63681e-01 8.13377e-04
+       1531    24 -228.453540 -228.398915 5.462550e-02   0.006 5.79521e-01 4.16384e-04
+       1532    25 -228.449235 -228.395176 5.405855e-02   0.006 4.97045e-01 4.93082e-04
+       1533    25 -228.434426 -228.392547 4.187855e-02   0.006 3.61566e-01 7.79764e-04
+       1534    24 -228.415169 -228.391359 2.380954e-02   0.006 2.58061e-01 8.90976e-04
+       1535    24 -228.397726 -228.391682 6.043970e-03   0.006 2.69645e-01 7.93269e-04
+       1536    24 -228.384882 -228.393072 8.190023e-03   0.006 3.25978e-01 5.55182e-04
+       1537    24 -228.378584 -228.394945 1.636076e-02   0.006 3.44582e-01 3.10104e-04
+       1538    25 -228.380223 -228.396827 1.660413e-02   0.006 3.11289e-01 3.07626e-04
+       1539    25 -228.386756 -228.398135 1.137882e-02   0.006 2.47358e-01 4.67103e-04
+       1540    24 -228.394881 -228.398585 3.703464e-03   0.006 1.98180e-01 5.48503e-04
+       1541    24 -228.402206 -228.398175 4.030903e-03   0.006 2.01891e-01 5.12694e-04
+       1542    24 -228.408628 -228.397201 1.142648e-02   0.006 2.32190e-01 3.98218e-04
+       1543    24 -228.414327 -228.395976 1.835157e-02   0.006 2.47317e-01 2.42713e-04
+       1544    25 -228.414338 -228.394629 1.970963e-02   0.006 2.34414e-01 1.98244e-04
+       1545    25 -228.410364 -228.393527 1.683630e-02   0.006 2.01400e-01 2.77171e-04
+       1546    25 -228.404886 -228.392931 1.195541e-02   0.006 1.69227e-01 3.28273e-04
+       1547    23 -228.399608 -228.392809 6.798058e-03   0.006 1.56601e-01 3.23414e-04
+       1548    24 -228.395347 -228.393054 2.292984e-03   0.006 1.62666e-01 2.69547e-04
+       1549    25 -228.393091 -228.393547 4.563035e-04   0.006 1.69589e-01 2.00590e-04
+       1550    24 -228.392509 -228.394101 1.591877e-03   0.006 1.65734e-01 1.71521e-04
+       1551    25 -228.393560 -228.394543 9.836473e-04   0.006 1.52018e-01 1.99260e-04
+       1552    24 -228.395435 -228.394765 6.708412e-04   0.006 1.37100e-01 2.32088e-04
+       1553    23 -228.397466 -228.394726 2.739508e-03   0.006 1.30063e-01 2.38221e-04
+       1554    25 -228.399053 -228.394461 4.591330e-03   0.006 1.31566e-01 2.16476e-04
+       1555    25 -228.399801 -228.394047 5.753898e-03   0.006 1.34431e-01 1.83486e-04
+       1556    25 -228.399679 -228.393588 6.090481e-03   0.006 1.32434e-01 1.63719e-04
+       1557    25 -228.398773 -228.393183 5.590073e-03   0.006 1.24920e-01 1.68373e-04
+       1558    25 -228.397543 -228.392912 4.630774e-03   0.006 1.15546e-01 1.79819e-04
+       1559    24 -228.396144 -228.392781 3.363325e-03   0.006 1.08685e-01 1.85285e-04
+       1560    24 -228.394931 -228.392777 2.154028e-03   0.006 1.06067e-01 1.79976e-04
+       1561    24 -228.394181 -228.392875 1.306378e-03   0.006 1.05565e-01 1.69215e-04
+       1562    24 -228.393898 -228.393020 8.778470e-04   0.006 1.04275e-01 1.61982e-04
+       1563    25 -228.394063 -228.393153 9.102001e-04   0.006 1.01005e-01 1.63166e-04
+       1564    24 -228.394605 -228.393231 1.374302e-03   0.006 9.66737e-02 1.69242e-04
+       1565    25 -228.395041 -228.393231 1.810585e-03   0.006 9.30467e-02 1.73767e-04
+       1566    24 -228.395521 -228.393151 2.370091e-03   0.006 9.10721e-02 1.73658e-04
+       1567    24 -228.395654 -228.393013 2.641476e-03   0.006 9.00973e-02 1.70233e-04
+       1568    24 -228.395539 -228.392845 2.693303e-03   0.006 8.88077e-02 1.66939e-04
+       1569    24 -228.395247 -228.392683 2.564412e-03   0.006 8.64718e-02 1.66208e-04
+       1570    24 -228.394667 -228.392551 2.115492e-03   0.006 8.32865e-02 1.67755e-04
+       1571    24 -228.394219 -228.392467 1.752217e-03   0.006 8.01321e-02 1.69619e-04
+       1572    24 -228.393766 -228.392433 1.332720e-03   0.006 7.76458e-02 1.70309e-04
+       1573    23 -228.393544 -228.392440 1.104501e-03   0.006 7.59049e-02 1.69869e-04
+       1574    23 -228.393484 -228.392470 1.014065e-03   0.006 7.44570e-02 1.69350e-04
+       1575    24 -228.393543 -228.392504 1.038645e-03   0.006 7.29001e-02 1.69663e-04
+       1576    24 -228.393795 -228.392524 1.271358e-03   0.006 7.11790e-02 1.70837e-04
+       1577    23 -228.393973 -228.392519 1.454051e-03   0.006 6.95175e-02 1.72212e-04
+       1578    23 -228.394177 -228.392486 1.690738e-03   0.006 6.81247e-02 1.73145e-04
+       1579    23 -228.394158 -228.392430 1.728306e-03   0.006 6.69704e-02 1.73496e-04
+       1580    23 -228.394248 -228.392359 1.889273e-03   0.006 6.58733e-02 1.73588e-04
+       1581    23 -228.393992 -228.392286 1.705655e-03   0.006 6.45808e-02 1.73811e-04
+       1582    24 -228.393810 -228.392222 1.588357e-03   0.006 6.30955e-02 1.74310e-04
+       1583    23 -228.393522 -228.392173 1.349139e-03   0.006 6.15095e-02 1.74955e-04
+       1584    22 -228.393387 -228.392142 1.244927e-03   0.006 6.00078e-02 1.75535e-04
+       1585    23 -228.393277 -228.392129 1.148791e-03   0.006 5.86615e-02 1.75962e-04
+       1586    22 -228.393168 -228.392126 1.041579e-03   0.006 5.74751e-02 1.76307e-04
+       1587    23 -228.393207 -228.392127 1.079766e-03   0.006 5.63785e-02 1.76691e-04
+       1588    22 -228.393258 -228.392127 1.131190e-03   0.006 5.53414e-02 1.77167e-04
+       1589    23 -228.393331 -228.392118 1.212675e-03   0.006 5.43476e-02 1.77695e-04
+       1590    23 -228.393417 -228.392101 1.316521e-03   0.006 5.34308e-02 1.78192e-04
+       1591    24 -228.393509 -228.392074 1.435462e-03   0.006 5.25744e-02 1.78606e-04
+       1592    23 -228.393514 -228.392041 1.472246e-03   0.006 5.17500e-02 1.78948e-04
+       1593    23 -228.393335 -228.392006 1.328765e-03   0.006 5.08914e-02 1.79261e-04
+       1594    22 -228.393442 -228.391972 1.470264e-03   0.006 5.00193e-02 1.79583e-04
+       1595    23 -228.393196 -228.391943 1.252605e-03   0.006 4.90786e-02 1.79916e-04
+       1596    20 -228.393193 -228.391920 1.272333e-03   0.006 4.81748e-02 1.80243e-04
+       1597    23 -228.392980 -228.391904 1.075287e-03   0.006 4.72583e-02 1.80546e-04
+       1598    22 -228.393100 -228.391893 1.206498e-03   0.006 4.64426e-02 1.80825e-04
+       1599    22 -228.392940 -228.391886 1.053789e-03   0.006 4.56393e-02 1.81091e-04
+       1600    23 -228.393143 -228.391878 1.265337e-03   0.006 4.49064e-02 1.81356e-04
+       1601    22 -228.393065 -228.391869 1.195707e-03   0.006 4.42091e-02 1.81620e-04
+       1602    22 -228.393108 -228.391857 1.251067e-03   0.006 4.35461e-02 1.81876e-04
+       1603    21 -228.393117 -228.391841 1.275957e-03   0.006 4.29149e-02 1.82114e-04
+       1604    21 -228.393217 -228.391824 1.393666e-03   0.006 4.22998e-02 1.82333e-04
+       1605    21 -228.393064 -228.391805 1.259778e-03   0.006 4.16865e-02 1.82535e-04
+       1606    21 -228.393080 -228.391785 1.295260e-03   0.006 4.10685e-02 1.82726e-04
+       1607    20 -228.393042 -228.391768 1.273910e-03   0.006 4.04465e-02 1.82912e-04
+       1608    20 -228.392956 -228.391754 1.201715e-03   0.006 3.98240e-02 1.83093e-04
+       1609    22 -228.393069 -228.391742 1.326935e-03   0.006 3.92061e-02 1.83267e-04
+       1610    19 -228.393024 -228.391731 1.292437e-03   0.006 3.86280e-02 1.83429e-04
+       1611    21 -228.393166 -228.391721 1.444809e-03   0.006 3.80399e-02 1.83583e-04
+       1612    19 -228.393030 -228.391712 1.318322e-03   0.006 3.75143e-02 1.83728e-04
+       1613    19 -228.393120 -228.391702 1.418485e-03   0.006 3.69831e-02 1.83867e-04
+       1614    20 -228.393230 -228.391691 1.538762e-03   0.006 3.64932e-02 1.84000e-04
+       1615    20 -228.392967 -228.391681 1.285641e-03   0.006 3.60061e-02 1.84125e-04
+       1616    20 -228.393198 -228.391669 1.529132e-03   0.006 3.55415e-02 1.84241e-04
+       1617    20 -228.393003 -228.391659 1.344621e-03   0.006 3.50736e-02 1.84348e-04
+       1618    20 -228.393211 -228.391646 1.564872e-03   0.006 3.46197e-02 1.84449e-04
+       1619    20 -228.393011 -228.391636 1.375046e-03   0.006 3.41575e-02 1.84544e-04
+       1620    20 -228.393210 -228.391624 1.585231e-03   0.006 3.37091e-02 1.84633e-04
+       1621    20 -228.393030 -228.391615 1.415429e-03   0.006 3.32587e-02 1.84715e-04
+       1622    20 -228.393198 -228.391605 1.593213e-03   0.006 3.28270e-02 1.84791e-04
+       1623    20 -228.393034 -228.391597 1.437500e-03   0.006 3.23997e-02 1.84860e-04
+       1624    20 -228.393185 -228.391588 1.597430e-03   0.006 3.19934e-02 1.84923e-04
+       1625    20 -228.393034 -228.391580 1.454022e-03   0.006 3.15927e-02 1.84980e-04
+       1626    20 -228.393184 -228.391572 1.612338e-03   0.006 3.12114e-02 1.85032e-04
+       1627    20 -228.393019 -228.391565 1.453742e-03   0.006 3.08324e-02 1.85078e-04
+       1628    20 -228.393198 -228.391557 1.641045e-03   0.006 3.04706e-02 1.85117e-04
+       1629    20 -228.393009 -228.391550 1.459825e-03   0.006 3.01059e-02 1.85151e-04
+       1630    20 -228.393181 -228.391541 1.640051e-03   0.006 2.97556e-02 1.85178e-04
+       1631    20 -228.393021 -228.391534 1.486959e-03   0.006 2.94022e-02 1.85200e-04
+       1632    20 -228.393178 -228.391525 1.652865e-03   0.006 2.90626e-02 1.85214e-04
+       1633    20 -228.393017 -228.391518 1.498503e-03   0.006 2.87212e-02 1.85222e-04
+       1634    20 -228.393148 -228.391511 1.637468e-03   0.006 2.83951e-02 1.85220e-04
+       1635    20 -228.393006 -228.391504 1.502039e-03   0.006 2.80712e-02 1.85206e-04
+       1636    19 -228.391711 -228.391498 2.130869e-04   0.006 2.89756e-02 1.76671e-04
+       1637    21 -228.389661 -228.391531 1.869559e-03   0.006 3.57272e-02 1.69101e-04
+       1638    22 -228.387626 -228.391625 3.999361e-03   0.006 4.39409e-02 1.63536e-04
+       1639    21 -228.386933 -228.391750 4.816423e-03   0.006 4.73990e-02 1.60716e-04
+       1640    21 -228.387503 -228.391875 4.372010e-03   0.006 4.40682e-02 1.60817e-04
+       1641    20 -228.389273 -228.391972 2.699327e-03   0.006 3.57430e-02 1.63343e-04
+       1642    21 -228.391550 -228.392021 4.709985e-04   0.006 2.76968e-02 1.65649e-04
+       1643    19 -228.393866 -228.392018 1.848521e-03   0.006 2.61201e-02 1.65764e-04
+       1644    21 -228.395635 -228.391969 3.665985e-03   0.006 3.02600e-02 1.63907e-04
+       1645    19 -228.396742 -228.391890 4.852166e-03   0.006 3.43869e-02 1.61502e-04
+       1646    21 -228.397071 -228.391798 5.273083e-03   0.006 3.55482e-02 1.60021e-04
+       1647    21 -228.396519 -228.391711 4.807378e-03   0.006 3.30843e-02 1.60078e-04
+       1648    21 -228.395096 -228.391643 3.452838e-03   0.006 2.77735e-02 1.61235e-04
+       1649    20 -228.393690 -228.391608 2.081455e-03   0.006 2.45586e-02 1.61933e-04
+       1650    19 -228.392795 -228.391602 1.193077e-03   0.006 2.39331e-02 1.61983e-04
+       1651    21 -228.391747 -228.391618 1.289522e-04   0.006 2.49844e-02 1.61323e-04
+       1652    19 -228.390955 -228.391652 6.973674e-04   0.006 2.69410e-02 1.60308e-04
+       1653    20 -228.389461 -228.391699 2.238017e-03   0.006 3.24506e-02 1.44622e-04
+       1654    20 -228.385867 -228.391783 5.916229e-03   0.006 5.09781e-02 1.17292e-04
+       1655    22 -228.383273 -228.391963 8.689597e-03   0.006 6.55455e-02 9.26476e-05
+       1656    25 -228.381844 -228.392178 1.033423e-02   0.006 7.31992e-02 7.89031e-05
+       1657    23 -228.381821 -228.392407 1.058558e-02   0.006 7.34849e-02 7.27328e-05
+       1658    24 -228.382909 -228.392622 9.712133e-03   0.006 6.67228e-02 7.45491e-05
+       1659    25 -228.385032 -228.392800 7.768002e-03   0.006 5.42128e-02 8.55809e-05
+       1660    24 -228.387910 -228.392926 5.016418e-03   0.006 3.84110e-02 9.79752e-05
+       1661    21 -228.391099 -228.392988 1.889208e-03   0.006 2.43384e-02 1.04607e-04
+       1662    20 -228.394241 -228.392983 1.258195e-03   0.006 2.26347e-02 1.03899e-04
+       1663    21 -228.397043 -228.392915 4.128313e-03   0.006 3.33011e-02 9.72232e-05
+       1664    21 -228.399254 -228.392796 6.457824e-03   0.006 4.47807e-02 8.67265e-05
+       1665    21 -228.400633 -228.392641 7.991846e-03   0.006 5.25160e-02 7.55463e-05
+       1666    24 -228.401107 -228.392471 8.636020e-03   0.006 5.51282e-02 6.81773e-05
+       1667    23 -228.400684 -228.392303 8.381309e-03   0.006 5.25141e-02 6.80141e-05
+       1668    23 -228.399420 -228.392154 7.266123e-03   0.006 4.53574e-02 7.38194e-05
+       1669    24 -228.397590 -228.392039 5.550334e-03   0.006 3.52132e-02 8.12826e-05
+       1670    21 -228.395323 -228.391968 3.355492e-03   0.006 2.47496e-02 8.68260e-05
+       1671    21 -228.393043 -228.391944 1.099265e-03   0.006 1.92711e-02 8.85899e-05
+       1672    21 -228.390876 -228.391968 1.092458e-03   0.006 2.30825e-02 8.62540e-05
+       1673    21 -228.389057 -228.392033 2.975722e-03   0.006 3.08270e-02 8.07899e-05
+       1674    21 -228.387783 -228.392128 4.344961e-03   0.006 3.73592e-02 7.41730e-05
+       1675    21 -228.387147 -228.392242 5.094059e-03   0.006 4.07608e-02 6.89347e-05
+       1676    24 -228.387140 -228.392359 5.218659e-03   0.006 4.05088e-02 6.71324e-05
+       1677    20 -228.387847 -228.392469 4.621415e-03   0.006 3.68538e-02 6.90284e-05
+       1678    21 -228.388950 -228.392558 3.607683e-03   0.006 3.06552e-02 7.29881e-05
+       1679    22 -228.390478 -228.392618 2.140192e-03   0.006 2.35424e-02 7.68127e-05
+       1680    20 -228.392131 -228.392646 5.140312e-04   0.006 1.82985e-02 7.89007e-05
+       1681    19 -228.393730 -228.392638 1.092078e-03   0.006 1.82409e-02 7.85862e-05
+       1682    20 -228.395156 -228.392598 2.557789e-03   0.006 2.24809e-02 7.61369e-05
+       1683    20 -228.396259 -228.392533 3.726055e-03   0.006 2.73178e-02 7.25522e-05
+       1684    21 -228.396911 -228.392451 4.459351e-03   0.006 3.05850e-02 6.92175e-05
+       1685    21 -228.397095 -228.392362 4.733229e-03   0.006 3.14806e-02 6.73946e-05
+       1686    22 -228.396816 -228.392275 4.541347e-03   0.006 2.99211e-02 6.76064e-05
+       1687    20 -228.396120 -228.392198 3.921777e-03   0.006 2.63556e-02 6.93810e-05
+       1688    21 -228.395144 -228.392141 3.003541e-03   0.006 2.17275e-02 7.16300e-05
+       1689    20 -228.393974 -228.392106 1.867853e-03   0.006 1.75968e-02 7.32882e-05
+       1690    20 -228.392784 -228.392096 6.883942e-04   0.006 1.59612e-02 7.37179e-05
+       1691    20 -228.391701 -228.392110 4.097921e-04   0.006 1.74929e-02 7.28378e-05
+       1692    21 -228.390774 -228.392145 1.371771e-03   0.006 2.04888e-02 7.10738e-05
+       1693    21 -228.390157 -228.392196 2.038212e-03   0.006 2.30978e-02 6.91475e-05
+       1694    21 -228.389863 -228.392254 2.391062e-03   0.006 2.43627e-02 6.77974e-05
+       1695    21 -228.389923 -228.392315 2.391721e-03   0.006 2.39824e-02 6.74659e-05
+       1696    21 -228.390292 -228.392370 2.078043e-03   0.006 2.21165e-02 6.81111e-05
+       1697    21 -228.390911 -228.392414 1.502788e-03   0.006 1.93010e-02 6.92790e-05
+       1698    21 -228.391699 -228.392443 7.442793e-04   0.006 1.64417e-02 7.03738e-05
+       1699    21 -228.392566 -228.392454 1.121539e-04   0.006 1.47108e-02 7.09314e-05
+       1700    20 -228.393375 -228.392448 9.278713e-04   0.006 1.48670e-02 7.07649e-05
+       1701    20 -228.394103 -228.392425 1.678874e-03   0.006 1.64259e-02 6.99989e-05
+       1702    21 -228.394647 -228.392389 2.257840e-03   0.006 1.82355e-02 6.89791e-05
+       1703    21 -228.394953 -228.392345 2.608578e-03   0.006 1.94284e-02 6.81167e-05
+       1704    21 -228.395011 -228.392298 2.713108e-03   0.006 1.96059e-02 6.77207e-05
+       1705    21 -228.394835 -228.392252 2.582506e-03   0.006 1.87418e-02 6.78742e-05
+       1706    21 -228.394455 -228.392213 2.242274e-03   0.006 1.71014e-02 6.84204e-05
+       1707    21 -228.393928 -228.392184 1.744545e-03   0.006 1.52015e-02 6.90643e-05
+       1708    21 -228.393320 -228.392167 1.152839e-03   0.006 1.37268e-02 6.95171e-05
+       1709    20 -228.392705 -228.392163 5.415512e-04   0.006 1.32517e-02 6.96099e-05
+       1710    21 -228.392139 -228.392172 3.336649e-05   0.006 1.37980e-02 6.93408e-05
+       1711    21 -228.391693 -228.392191 4.983020e-04   0.006 1.48273e-02 6.88525e-05
+       1712    21 -228.391390 -228.392218 8.273090e-04   0.006 1.57183e-02 6.83600e-05
+       1713    21 -228.391265 -228.392248 9.833124e-04   0.006 1.60743e-02 6.80562e-05
+       1714    21 -228.391320 -228.392279 9.588588e-04   0.006 1.57636e-02 6.80353e-05
+       1715    20 -228.391548 -228.392306 7.579101e-04   0.006 1.48817e-02 6.82655e-05
+       1716    19 -228.391852 -228.392328 4.754655e-04   0.006 1.37218e-02 6.86157e-05
+       1717    20 -228.392283 -228.392341 5.796179e-05   0.006 1.26704e-02 6.89260e-05
+       1718    20 -228.392747 -228.392345 4.022909e-04   0.006 1.21146e-02 6.90785e-05
+       1719    19 -228.393150 -228.392340 8.102056e-04   0.006 1.21899e-02 6.90305e-05
+       1720    20 -228.393519 -228.392326 1.192541e-03   0.006 1.27025e-02 6.88285e-05
+       1721    20 -228.393780 -228.392307 1.473107e-03   0.006 1.32855e-02 6.85759e-05
+       1722    20 -228.393903 -228.392283 1.620132e-03   0.006 1.36245e-02 6.83833e-05
+       1723    20 -228.393935 -228.392258 1.677714e-03   0.006 1.35753e-02 6.83257e-05
+       1724    20 -228.393815 -228.392234 1.580709e-03   0.006 1.31242e-02 6.84128e-05
+       1725    20 -228.393612 -228.392214 1.397726e-03   0.006 1.24191e-02 6.85950e-05
+       1726    20 -228.393312 -228.392200 1.112786e-03   0.006 1.16791e-02 6.87920e-05
+       1727    20 -228.393028 -228.392192 8.367017e-04   0.006 1.11567e-02 6.89266e-05
+       1728    19 -228.392675 -228.392190 4.843016e-04   0.006 1.09831e-02 6.89613e-05
+       1729    19 -228.392402 -228.392195 2.065792e-04   0.006 1.11329e-02 6.89015e-05
+       1730    19 -228.392183 -228.392206 2.260708e-05   0.006 1.14272e-02 6.87904e-05
+       1731    21 -228.392034 -228.392219 1.851416e-04   0.006 1.16627e-02 6.86878e-05
+       1732    20 -228.391982 -228.392235 2.529823e-04   0.006 1.16985e-02 6.86424e-05
+       1733    20 -228.392019 -228.392250 2.316996e-04   0.006 1.14907e-02 6.86734e-05
+       1734    20 -228.392140 -228.392264 1.238337e-04   0.006 1.10924e-02 6.87671e-05
+       1735    20 -228.392328 -228.392274 5.410189e-05   0.006 1.06236e-02 6.88866e-05
+       1736    19 -228.392539 -228.392280 2.592962e-04   0.006 1.02313e-02 6.89896e-05
+       1737    20 -228.392781 -228.392281 4.995332e-04   0.006 1.00222e-02 6.90466e-05
+       1738    19 -228.392980 -228.392277 7.027873e-04   0.006 1.00162e-02 6.90500e-05
+       1739    20 -228.393177 -228.392270 9.078288e-04   0.006 1.01431e-02 6.90157e-05
+       1740    20 -228.393296 -228.392259 1.037659e-03   0.006 1.02805e-02 6.89727e-05
+       1741    20 -228.393369 -228.392246 1.123124e-03   0.006 1.03291e-02 6.89497e-05
+       1742    20 -228.393368 -228.392233 1.135176e-03   0.006 1.02343e-02 6.89637e-05
+       1743    19 -228.393292 -228.392220 1.072025e-03   0.006 1.00015e-02 6.90148e-05
+       1744    21 -228.393176 -228.392210 9.663028e-04   0.006 9.69311e-03 6.90883e-05
+       1745    19 -228.393014 -228.392203 8.116276e-04   0.006 9.39088e-03 6.91627e-05
+       1746    20 -228.392871 -228.392199 6.718705e-04   0.006 9.17524e-03 6.92179e-05
+       1747    19 -228.392689 -228.392198 4.906938e-04   0.006 9.07683e-03 6.92454e-05
+       1748    19 -228.392557 -228.392201 3.561601e-04   0.006 9.07858e-03 6.92486e-05
+       1749    20 -228.392426 -228.392206 2.194027e-04   0.006 9.12303e-03 6.92403e-05
+       1750    19 -228.392393 -228.392214 1.797950e-04   0.006 9.13972e-03 6.92359e-05
+       1751    19 -228.392333 -228.392222 1.109453e-04   0.006 9.08944e-03 6.92482e-05
+       1752    20 -228.392382 -228.392229 1.523679e-04   0.006 8.95424e-03 6.92804e-05
+       1753    19 -228.392434 -228.392236 1.982010e-04   0.006 8.76239e-03 6.93279e-05
+       1754    19 -228.392559 -228.392241 3.182968e-04   0.006 8.55479e-03 6.93807e-05
+       1755    20 -228.392643 -228.392243 4.001389e-04   0.006 8.38239e-03 6.94272e-05
+       1756    19 -228.392789 -228.392243 5.463501e-04   0.006 8.27523e-03 6.94605e-05
+       1757    19 -228.392876 -228.392241 6.358444e-04   0.006 8.23047e-03 6.94796e-05
+       1758    20 -228.392993 -228.392236 7.571239e-04   0.006 8.22858e-03 6.94893e-05
+       1759    19 -228.393020 -228.392230 7.900664e-04   0.006 8.22002e-03 6.94973e-05
+       1760    19 -228.393080 -228.392223 8.573962e-04   0.006 8.18492e-03 6.95115e-05
+       1761    20 -228.393055 -228.392216 8.390779e-04   0.006 8.09450e-03 6.95356e-05
+       1762    19 -228.393029 -228.392209 8.197848e-04   0.006 7.96377e-03 6.95690e-05
+       1763    19 -228.392949 -228.392204 7.448620e-04   0.006 7.80813e-03 6.96073e-05
+       1764    20 -228.392881 -228.392200 6.806701e-04   0.006 7.66180e-03 6.96455e-05
+       1765    19 -228.392796 -228.392199 5.971260e-04   0.006 7.54699e-03 6.96772e-05
+       1766    18 -228.392725 -228.392199 5.263291e-04   0.006 7.47062e-03 6.96969e-05
+       1767    18 -228.392650 -228.392201 4.496789e-04   0.006 7.41954e-03 6.97140e-05
+       1768    18 -228.392599 -228.392203 3.958590e-04   0.006 7.37923e-03 6.97293e-05
+       1769    18 -228.392572 -228.392207 3.646589e-04   0.006 7.32987e-03 6.97462e-05
+       1770    18 -228.392568 -228.392211 3.577450e-04   0.006 7.26002e-03 6.97672e-05
+       1771    18 -228.392586 -228.392214 3.721622e-04   0.006 7.16788e-03 6.97925e-05
+       1772    18 -228.392623 -228.392217 4.058301e-04   0.006 7.06286e-03 6.98208e-05
+       1773    18 -228.392674 -228.392219 4.547336e-04   0.006 6.95886e-03 6.98495e-05
+       1774    18 -228.392733 -228.392220 5.129412e-04   0.006 6.86825e-03 6.98790e-05
+       1775    18 -228.392799 -228.392220 5.793938e-04   0.006 6.80158e-03 6.99012e-05
+       1776    18 -228.392860 -228.392219 6.415044e-04   0.006 6.75441e-03 6.99205e-05
+       1777    19 -228.392892 -228.392216 6.758131e-04   0.006 6.71229e-03 6.99378e-05
+       1778    19 -228.392926 -228.392213 7.123966e-04   0.006 6.66601e-03 6.99539e-05
+       1779    18 -228.392936 -228.392210 7.256738e-04   0.006 6.61033e-03 6.99701e-05
+       1780    18 -228.392945 -228.392207 7.384306e-04   0.006 6.54884e-03 6.99884e-05
+       1781    18 -228.392935 -228.392203 7.318089e-04   0.006 6.47333e-03 7.00088e-05
+       1782    18 -228.392913 -228.392200 7.127786e-04   0.006 6.38474e-03 7.00306e-05
+       1783    18 -228.392879 -228.392198 6.810830e-04   0.006 6.29197e-03 7.00526e-05
+       1784    18 -228.392840 -228.392196 6.436852e-04   0.006 6.20327e-03 7.00736e-05
+       1785    18 -228.392798 -228.392195 6.027313e-04   0.006 6.12397e-03 7.00927e-05
+       1786    18 -228.392753 -228.392195 5.578150e-04   0.006 6.05529e-03 7.01097e-05
+       1787    18 -228.392725 -228.392196 5.293685e-04   0.006 5.99579e-03 7.01250e-05
+       1788    18 -228.392695 -228.392197 4.979739e-04   0.006 5.94000e-03 7.01393e-05
+       1789    18 -228.392682 -228.392199 4.831468e-04   0.006 5.88345e-03 7.01536e-05
+       1790    18 -228.392676 -228.392201 4.754518e-04   0.006 5.82246e-03 7.01684e-05
+       1791    18 -228.392684 -228.392202 4.812126e-04   0.006 5.75655e-03 7.01839e-05
+       1792    18 -228.392699 -228.392204 4.954388e-04   0.006 5.68774e-03 7.01998e-05
+       1793    18 -228.392723 -228.392205 5.183084e-04   0.006 5.61967e-03 7.02154e-05
+       1794    18 -228.392751 -228.392205 5.455158e-04   0.006 5.55587e-03 7.02303e-05
+       1795    18 -228.392797 -228.392205 5.916401e-04   0.006 5.49931e-03 7.02439e-05
+       1796    18 -228.392802 -228.392205 5.968634e-04   0.006 5.44695e-03 7.02561e-05
+       1797    18 -228.392839 -228.392203 6.359145e-04   0.006 5.40054e-03 7.02672e-05
+       1798    18 -228.392849 -228.392202 6.472405e-04   0.006 5.35319e-03 7.02776e-05
+       1799    18 -228.392864 -228.392200 6.643421e-04   0.006 5.30366e-03 7.02878e-05
+       1800    18 -228.392864 -228.392198 6.656100e-04   0.006 5.24842e-03 7.02981e-05
+       1801    18 -228.392860 -228.392196 6.636758e-04   0.006 5.18805e-03 7.03085e-05
+       1802    18 -228.392847 -228.392195 6.517826e-04   0.006 5.12354e-03 7.03189e-05
+       1803    18 -228.392830 -228.392193 6.362260e-04   0.006 5.05787e-03 7.03289e-05
+       1804    18 -228.392808 -228.392193 6.159588e-04   0.006 4.99359e-03 7.03382e-05
+       1805    18 -228.392787 -228.392192 5.951824e-04   0.006 4.93282e-03 7.03465e-05
+       1806    18 -228.392782 -228.392192 5.903593e-04   0.006 4.87690e-03 7.03537e-05
+       1807    18 -228.392737 -228.392192 5.446545e-04   0.006 4.82243e-03 7.03601e-05
+       1808    18 -228.392741 -228.392193 5.475353e-04   0.006 4.77185e-03 7.03658e-05
+       1809    18 -228.392723 -228.392194 5.295378e-04   0.006 4.72060e-03 7.03710e-05
+       1810    18 -228.392728 -228.392195 5.327680e-04   0.006 4.66922e-03 7.03759e-05
+       1811    18 -228.392728 -228.392196 5.326352e-04   0.006 4.61664e-03 7.03806e-05
+       1812    18 -228.392739 -228.392196 5.429574e-04   0.006 4.56405e-03 7.03850e-05
+       1813    18 -228.392751 -228.392197 5.539765e-04   0.006 4.51234e-03 7.03889e-05
+       1814    18 -228.392766 -228.392197 5.684560e-04   0.006 4.46277e-03 7.03921e-05
+       1815    18 -228.392787 -228.392197 5.896231e-04   0.006 4.41619e-03 7.03945e-05
+       1816    18 -228.392797 -228.392197 6.002576e-04   0.006 4.37148e-03 7.03961e-05
+       1817    18 -228.392812 -228.392196 6.163259e-04   0.006 4.32870e-03 7.03969e-05
+       1818    18 -228.392820 -228.392195 6.250370e-04   0.006 4.28579e-03 7.03971e-05
+       1819    18 -228.392827 -228.392194 6.325398e-04   0.006 4.24197e-03 7.03968e-05
+       1820    18 -228.392828 -228.392193 6.342785e-04   0.006 4.19621e-03 7.03960e-05
+       1821    18 -228.392825 -228.392192 6.327719e-04   0.006 4.14864e-03 7.03948e-05
+       1822    18 -228.392819 -228.392192 6.271927e-04   0.006 4.09977e-03 7.03930e-05
+       1823    18 -228.392810 -228.392191 6.189976e-04   0.006 4.05064e-03 7.03906e-05
+       1824    18 -228.392799 -228.392191 6.089660e-04   0.006 4.00227e-03 7.03875e-05
+       1825    18 -228.392789 -228.392190 5.985464e-04   0.006 3.95548e-03 7.03836e-05
+       1826    18 -228.392781 -228.392190 5.908480e-04   0.006 3.91061e-03 7.03789e-05
+       1827    18 -228.392765 -228.392191 5.743115e-04   0.006 3.86690e-03 7.03734e-05
+       1828    18 -228.392764 -228.392191 5.732495e-04   0.006 3.82511e-03 7.03671e-05
+       1829    18 -228.392759 -228.392191 5.670786e-04   0.006 3.78368e-03 7.03602e-05
+       1830    18 -228.392760 -228.392192 5.681905e-04   0.006 3.74288e-03 7.03526e-05
+       1831    18 -228.392762 -228.392192 5.698255e-04   0.006 3.70256e-03 7.03443e-05
+       1832    18 -228.392768 -228.392193 5.753867e-04   0.006 3.66264e-03 7.03354e-05
+       1833    18 -228.392775 -228.392193 5.817190e-04   0.006 3.62373e-03 7.03257e-05
+       1834    18 -228.392803 -228.392193 6.097189e-04   0.006 3.58736e-03 7.03153e-05
+       1835    18 -228.392768 -228.392194 5.745137e-04   0.006 3.54876e-03 7.03040e-05
+       1836    18 -228.392820 -228.392193 6.265567e-04   0.006 3.51660e-03 7.02918e-05
+       1837    18 -228.392802 -228.392193 6.092880e-04   0.006 3.48104e-03 7.02788e-05
+       1838    18 -228.392822 -228.392193 6.296169e-04   0.006 3.44839e-03 7.02649e-05
+       1839    18 -228.392818 -228.392192 6.254131e-04   0.006 3.41416e-03 7.02502e-05
+       1840    17 -228.392822 -228.392192 6.298152e-04   0.006 3.38088e-03 7.02342e-05
+       1841    16 -228.392821 -228.392191 6.299089e-04   0.006 3.34423e-03 7.02170e-05
+       1842    16 -228.392820 -228.392191 6.284660e-04   0.006 3.31142e-03 7.01992e-05
+       1843    17 -228.392815 -228.392191 6.238361e-04   0.006 3.27735e-03 7.01809e-05
+       1844    16 -228.392813 -228.392191 6.226775e-04   0.006 3.24530e-03 7.01615e-05
+       1845    16 -228.392807 -228.392191 6.160908e-04   0.006 3.21161e-03 7.01410e-05
+       1846    16 -228.392806 -228.392191 6.153149e-04   0.006 3.18239e-03 7.01194e-05
+       1847    16 -228.392834 -228.392191 6.431340e-04   0.006 3.15334e-03 7.00967e-05
+       1848    16 -228.392779 -228.392191 5.871574e-04   0.006 3.12321e-03 7.00727e-05
+       1849    17 -228.392807 -228.392192 6.153821e-04   0.006 3.09723e-03 7.00475e-05
+       1850    16 -228.392797 -228.392192 6.048020e-04   0.006 3.06984e-03 7.00209e-05
+       1851    16 -228.392810 -228.392193 6.173562e-04   0.006 3.04673e-03 6.99929e-05
+       1852    17 -228.392823 -228.392193 6.296739e-04   0.006 3.02463e-03 6.99634e-05
+       1853    16 -228.392811 -228.392193 6.171798e-04   0.006 3.00286e-03 6.99322e-05
+       1854    16 -228.392831 -228.392194 6.372002e-04   0.006 2.98359e-03 6.98991e-05
+       1855    16 -228.392139 -228.392194 5.482640e-05   0.006 6.21631e-03 5.06897e-05
+       1856    19 -228.391343 -228.392268 9.246971e-04   0.006 1.24452e-02 4.15299e-05
+       1857    20 -228.390740 -228.392391 1.650568e-03   0.006 1.68703e-02 2.92010e-05
+       1858    23 -228.390517 -228.392540 2.022672e-03   0.006 1.87807e-02 1.57773e-05
+       1859    24 -228.390590 -228.392691 2.101275e-03   0.006 1.80915e-02 1.10339e-05
+       1860    25 -228.390927 -228.392825 1.897878e-03   0.006 1.51602e-02 2.02348e-05
+       1861    23 -228.391465 -228.392925 1.459929e-03   0.006 1.05846e-02 2.94472e-05
+       1862    20 -228.392129 -228.392981 8.518593e-04   0.006 5.32147e-03 3.48245e-05
+       1863    18 -228.392776 -228.392990 2.134785e-04   0.006 2.88746e-03 3.56038e-05
+       1864    18 -228.393371 -228.392953 4.180406e-04   0.006 6.76635e-03 3.20206e-05
+       1865    18 -228.393816 -228.392881 9.351819e-04   0.006 1.03848e-02 2.50513e-05
+       1866    20 -228.394078 -228.392785 1.292632e-03   0.006 1.24907e-02 1.66002e-05
+       1867    23 -228.394145 -228.392683 1.461703e-03   0.006 1.29325e-02 1.18855e-05
+       1868    24 -228.394074 -228.392593 1.481036e-03   0.006 1.17595e-02 1.20475e-05
+       1869    24 -228.393764 -228.392516 1.248409e-03   0.006 9.30557e-03 1.75875e-05
+       1870    20 -228.393347 -228.392464 8.833535e-04   0.006 6.09453e-03 2.22115e-05
+       1871    20 -228.392954 -228.392442 5.118166e-04   0.006 3.04702e-03 2.42054e-05
+       1872    19 -228.392512 -228.392449 6.279720e-05   0.006 2.96734e-03 2.35598e-05
+       1873    21 -228.392175 -228.392482 3.072606e-04   0.006 5.32853e-03 2.05710e-05
+       1874    20 -228.391939 -228.392534 5.946003e-04   0.006 7.26258e-03 1.60887e-05
+       1875    23 -228.391812 -228.392597 7.848496e-04   0.006 8.21750e-03 1.16143e-05
+       1876    24 -228.391822 -228.392661 8.386972e-04   0.006 8.09406e-03 9.68768e-06
+       1877    24 -228.391949 -228.392719 7.696077e-04   0.006 6.99745e-03 1.15358e-05
+       1878    22 -228.392171 -228.392764 5.922247e-04   0.006 5.21629e-03 1.46006e-05
+       1879    20 -228.392434 -228.392790 3.555857e-04   0.006 3.21313e-03 1.68023e-05
+       1880    19 -228.392715 -228.392796 8.106719e-05   0.006 2.14510e-03 1.74660e-05
+       1881    19 -228.392965 -228.392785 1.797240e-04   0.006 3.17005e-03 1.65209e-05
+       1882    20 -228.393153 -228.392758 3.951765e-04   0.006 4.64073e-03 1.43423e-05
+       1883    20 -228.393285 -228.392720 5.643465e-04   0.006 5.66592e-03 1.16832e-05
+       1884    21 -228.393312 -228.392678 6.337929e-04   0.006 6.01254e-03 9.70038e-06
+       1885    21 -228.393267 -228.392637 6.305598e-04   0.006 5.69284e-03 9.62940e-06
+       1886    21 -228.393178 -228.392603 5.758670e-04   0.006 4.82000e-03 1.07713e-05
+       1887    21 -228.393003 -228.392578 4.251991e-04   0.006 3.59863e-03 1.23021e-05
+       1888    19 -228.392836 -228.392566 2.706005e-04   0.006 2.41371e-03 1.32264e-05
+       1889    20 -228.392666 -228.392566 1.001491e-04   0.006 1.94346e-03 1.32437e-05
+       1890    19 -228.392511 -228.392578 6.651639e-05   0.006 2.47292e-03 1.24523e-05
+       1891    20 -228.392402 -228.392598 1.956338e-04   0.006 3.21885e-03 1.11599e-05
+       1892    19 -228.392354 -228.392624 2.694472e-04   0.006 3.69507e-03 9.88641e-06
+       1893    21 -228.392347 -228.392651 3.036627e-04   0.006 3.77559e-03 9.20101e-06
+       1894    21 -228.392400 -228.392676 2.768101e-04   0.006 3.45977e-03 9.34792e-06
+       1895    21 -228.392481 -228.392697 2.157839e-04   0.006 2.86218e-03 1.00210e-05
+       1896    20 -228.392590 -228.392710 1.194971e-04   0.006 2.18284e-03 1.07010e-05
+       1897    19 -228.392702 -228.392715 1.323805e-05   0.006 1.77174e-03 1.10284e-05
+       1898    20 -228.392812 -228.392712 1.004656e-04   0.006 1.91582e-03 1.08872e-05
+       1899    19 -228.392893 -228.392702 1.908683e-04   0.006 2.37838e-03 1.03759e-05
+       1900    20 -228.392954 -228.392687 2.675856e-04   0.006 2.80455e-03 9.72707e-06
+       1901    19 -228.392970 -228.392669 3.011738e-04   0.006 3.01899e-03 9.18841e-06
+       1902    21 -228.392960 -228.392652 3.080456e-04   0.006 2.98410e-03 8.99973e-06
+       1903    20 -228.392911 -228.392636 2.747066e-04   0.006 2.71683e-03 9.15564e-06
+       1904    19 -228.392846 -228.392624 2.216930e-04   0.006 2.30421e-03 9.48046e-06
+       1905    19 -228.392772 -228.392618 1.547205e-04   0.006 1.87767e-03 9.75752e-06
+       1906    19 -228.392693 -228.392616 7.681641e-05   0.006 1.60599e-03 9.84680e-06
+       1907    20 -228.392630 -228.392620 1.029231e-05   0.006 1.59774e-03 9.71868e-06
+       1908    19 -228.392577 -228.392628 5.105450e-05   0.006 1.76284e-03 9.44074e-06
+       1909    19 -228.392551 -228.392638 8.742198e-05   0.006 1.92968e-03 9.13740e-06
+       1910    20 -228.392543 -228.392650 1.064185e-04   0.006 1.99658e-03 8.93190e-06
+       1911    19 -228.392566 -228.392661 9.556998e-05   0.006 1.93496e-03 8.88638e-06
+       1912    19 -228.392599 -228.392671 7.181592e-05   0.006 1.77412e-03 8.97505e-06
+       1913    20 -228.392646 -228.392677 3.093820e-05   0.006 1.58161e-03 9.11212e-06
+       1914    19 -228.392698 -228.392681 1.759476e-05   0.006 1.45080e-03 9.20778e-06
+       1915    19 -228.392747 -228.392680 6.645855e-05   0.006 1.44688e-03 9.21059e-06
+       1916    19 -228.392788 -228.392677 1.114310e-04   0.006 1.55117e-03 9.12097e-06
+       1917    20 -228.392812 -228.392671 1.412671e-04   0.006 1.68294e-03 8.98131e-06
+       1918    19 -228.392825 -228.392664 1.613703e-04   0.006 1.77267e-03 8.85108e-06
+       1919    19 -228.392822 -228.392656 1.665037e-04   0.006 1.78459e-03 8.77786e-06
+       1920    19 -228.392801 -228.392648 1.524183e-04   0.006 1.71400e-03 8.77535e-06
+       1921    19 -228.392774 -228.392643 1.310474e-04   0.006 1.58710e-03 8.82175e-06
+       1922    19 -228.392737 -228.392639 9.864794e-05   0.006 1.44299e-03 8.87664e-06
+       1923    19 -228.392700 -228.392637 6.226957e-05   0.006 1.32845e-03 8.90388e-06
+       1924    19 -228.392667 -228.392638 2.896186e-05   0.006 1.27393e-03 8.88692e-06
+       1925    19 -228.392641 -228.392641 6.423510e-07   0.006 1.27502e-03 8.83241e-06
+       1926    19 -228.392624 -228.392646 2.132606e-05   0.006 1.29980e-03 8.76310e-06
+       1927    19 -228.392618 -228.392651 3.224844e-05   0.006 1.31440e-03 8.70502e-06
+       1928    19 -228.392625 -228.392656 3.100825e-05   0.006 1.30076e-03 8.67499e-06
+       1929    19 -228.392639 -228.392661 2.150312e-05   0.006 1.26078e-03 8.67406e-06
+       1930    19 -228.392661 -228.392664 3.415073e-06   0.006 1.21062e-03 8.68970e-06
+       1931    19 -228.392686 -228.392666 2.026515e-05   0.006 1.17294e-03 8.70418e-06
+       1932    19 -228.392709 -228.392667 4.205885e-05   0.006 1.16352e-03 8.70383e-06
+       1933    19 -228.392733 -228.392666 6.735775e-05   0.006 1.18277e-03 8.68453e-06
+       1934    20 -228.392746 -228.392663 8.248379e-05   0.006 1.21417e-03 8.65185e-06
+       1935    19 -228.392756 -228.392660 9.633852e-05   0.006 1.24003e-03 8.61692e-06
+       1936    19 -228.392756 -228.392657 9.995276e-05   0.006 1.24441e-03 8.59021e-06
+       1937    19 -228.392750 -228.392653 9.735118e-05   0.006 1.22375e-03 8.57685e-06
+       1938    20 -228.392737 -228.392650 8.688883e-05   0.006 1.18199e-03 8.57500e-06
+       1939    19 -228.392721 -228.392648 7.280032e-05   0.006 1.13079e-03 8.57797e-06
+       1940    19 -228.392703 -228.392647 5.564963e-05   0.006 1.08315e-03 8.57805e-06
+       1941    20 -228.392684 -228.392647 3.757357e-05   0.006 1.04838e-03 8.57029e-06
+       1942    19 -228.392670 -228.392648 2.198368e-05   0.006 1.02902e-03 8.55425e-06
+       1943    19 -228.392658 -228.392649 8.694526e-06   0.006 1.02010e-03 8.53339e-06
+       1944    20 -228.392652 -228.392652 3.891507e-07   0.006 1.01371e-03 8.51280e-06
+       1945    19 -228.392652 -228.392654 2.009582e-06   0.006 1.00398e-03 8.49661e-06
+       1946    20 -228.392656 -228.392656 5.524084e-07   0.006 9.89202e-04 8.48626e-06
+       1947    19 -228.392665 -228.392658 6.536571e-06   0.006 9.72220e-04 8.48027e-06
+       1948    20 -228.392675 -228.392659 1.533589e-05   0.006 9.57734e-04 8.47548e-06
+       1949    19 -228.392688 -228.392660 2.789543e-05   0.006 9.49989e-04 8.46879e-06
+       1950    20 -228.392698 -228.392660 3.774038e-05   0.006 9.49337e-04 8.45862e-06
+       1951    19 -228.392708 -228.392659 4.904945e-05   0.006 9.53427e-04 8.44533e-06
+       1952    20 -228.392714 -228.392658 5.655341e-05   0.006 9.56748e-04 8.43076e-06
+       1953    19 -228.392717 -228.392656 6.047060e-05   0.006 9.55013e-04 8.41710e-06
+       1954    20 -228.392716 -228.392655 6.090084e-05   0.006 9.45550e-04 8.40579e-06
+       1955    19 -228.392713 -228.392653 5.928176e-05   0.006 9.29018e-04 8.39701e-06
+       1956    20 -228.392706 -228.392652 5.405524e-05   0.006 9.07715e-04 8.38975e-06
+       1957    19 -228.392698 -228.392651 4.673693e-05   0.006 8.85412e-04 8.38255e-06
+       1958    20 -228.392690 -228.392651 3.880194e-05   0.006 8.65233e-04 8.37413e-06
+       1959    18 -228.392682 -228.392651 3.045578e-05   0.006 8.49012e-04 8.36408e-06
+       1960    18 -228.392675 -228.392652 2.315481e-05   0.006 8.36372e-04 8.35271e-06
+       1961    18 -228.392670 -228.392653 1.726372e-05   0.006 8.26281e-04 8.34095e-06
+       1962    18 -228.392667 -228.392654 1.365187e-05   0.006 8.16983e-04 8.32974e-06
+       1963    18 -228.392667 -228.392655 1.228963e-05   0.006 8.07613e-04 8.31959e-06
+       1964    18 -228.392669 -228.392656 1.318240e-05   0.006 7.98227e-04 8.31046e-06
+       1965    18 -228.392672 -228.392656 1.593617e-05   0.006 7.89602e-04 8.30187e-06
+       1966    18 -228.392677 -228.392657 1.996220e-05   0.006 7.82549e-04 8.29319e-06
+       1967    18 -228.392682 -228.392657 2.463401e-05   0.006 7.77383e-04 8.28397e-06
+       1968    18 -228.392686 -228.392657 2.956094e-05   0.006 7.73506e-04 8.27414e-06
+       1969    18 -228.392690 -228.392656 3.344960e-05   0.006 7.69809e-04 8.26393e-06
+       1970    18 -228.392692 -228.392656 3.661719e-05   0.006 7.64927e-04 8.25375e-06
+       1971    18 -228.392693 -228.392655 3.826463e-05   0.006 7.58034e-04 8.24395e-06
+       1972    18 -228.392693 -228.392655 3.855030e-05   0.006 7.48789e-04 8.23465e-06
+       1973    18 -228.392691 -228.392654 3.741444e-05   0.006 7.37747e-04 8.22575e-06
+       1974    18 -228.392689 -228.392654 3.517193e-05   0.006 7.25727e-04 8.21700e-06
+       1975    18 -228.392685 -228.392653 3.214676e-05   0.006 7.13777e-04 8.20812e-06
+       1976    18 -228.392682 -228.392653 2.876072e-05   0.006 7.02591e-04 8.19897e-06
+       1977    18 -228.392677 -228.392653 2.350552e-05   0.006 6.92410e-04 8.18956e-06
+       1978    18 -228.392677 -228.392654 2.293851e-05   0.006 6.83479e-04 8.18002e-06
+       1979    18 -228.392673 -228.392654 1.926884e-05   0.006 6.75152e-04 8.17053e-06
+       1980    18 -228.392673 -228.392654 1.844948e-05   0.006 6.67473e-04 8.16121e-06
+       1981    18 -228.392672 -228.392655 1.731722e-05   0.006 6.60202e-04 8.15209e-06
+       1982    18 -228.392673 -228.392655 1.769923e-05   0.006 6.53463e-04 8.14311e-06
+       1983    18 -228.392674 -228.392655 1.833159e-05   0.006 6.47266e-04 8.13416e-06
+       1984    18 -228.392675 -228.392656 1.965988e-05   0.006 6.41621e-04 8.12514e-06
+       1985    18 -228.392677 -228.392656 2.100984e-05   0.006 6.36320e-04 8.11602e-06
+       1986    18 -228.392677 -228.392655 2.122907e-05   0.006 6.30989e-04 8.10684e-06
+       1987    18 -228.392680 -228.392655 2.503718e-05   0.006 6.25556e-04 8.09765e-06
+       1988    18 -228.392680 -228.392655 2.465520e-05   0.006 6.19297e-04 8.08855e-06
+       1989    18 -228.392680 -228.392655 2.542652e-05   0.006 6.12439e-04 8.07955e-06
+       1990    18 -228.392680 -228.392655 2.514382e-05   0.006 6.04935e-04 8.07065e-06
+       1991    18 -228.392679 -228.392654 2.472611e-05   0.006 5.97070e-04 8.06180e-06
+       1992    18 -228.392678 -228.392654 2.380661e-05   0.006 5.89104e-04 8.05295e-06
+       1993    18 -228.392677 -228.392654 2.275254e-05   0.006 5.81301e-04 8.04407e-06
+       1994    18 -228.392676 -228.392654 2.163844e-05   0.006 5.73818e-04 8.03514e-06
+       1995    18 -228.392675 -228.392654 2.115116e-05   0.006 5.66747e-04 8.02620e-06
+       1996    18 -228.392673 -228.392654 1.813326e-05   0.006 5.59916e-04 8.01727e-06
+       1997    18 -228.392674 -228.392655 1.984311e-05   0.006 5.53660e-04 8.00838e-06
+       1998    18 -228.392671 -228.392655 1.671579e-05   0.006 5.47462e-04 7.99955e-06
+       1999    18 -228.392676 -228.392655 2.117728e-05   0.006 5.41942e-04 7.99076e-06
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization converged in  13 iterations 
+            Total energy change: -6.850494e-04
+            Final gradient norm: 3.021147e-07
+
+       2000    18 -228.393355 -228.385676 7.679132e-03   0.371 5.36147e-04 7.98200e-06
+       2001    29 -228.393172 -228.393344 1.727735e-04   0.371 1.34325e-03 1.97811e-04
+       2002    20 -228.393338 -228.393294 4.373324e-05   0.371 2.20200e-04 1.60424e-04
+       2003    19 -228.393393 -228.393278 1.155230e-04   0.371 3.43611e-04 7.95361e-05
+       2004    22 -228.393350 -228.393270 7.950409e-05   0.371 1.20029e-04 6.58970e-05
+       2005    22 -228.393327 -228.393244 8.270546e-05   0.371 1.20266e-04 6.12658e-05
+       2006    19 -228.393330 -228.393221 1.096519e-04   0.371 7.73638e-05 5.98521e-05
+       2007    20 -228.393333 -228.393213 1.197256e-04   0.371 6.24247e-05 5.79839e-05
+       2008    20 -228.393328 -228.393217 1.114169e-04   0.371 6.26755e-05 5.45897e-05
+       2009    20 -228.393325 -228.393231 9.343013e-05   0.371 7.23708e-05 4.95309e-05
+       2010    20 -228.393324 -228.393256 6.829504e-05   0.371 8.49756e-05 4.25670e-05
+       2011    22 -228.393325 -228.393288 3.668390e-05   0.371 9.65927e-05 3.43539e-05
+       2012    23 -228.393326 -228.393325 1.510283e-06   0.371 1.02744e-04 2.67415e-05
+       2013    24 -228.393329 -228.393362 3.319707e-05   0.371 1.01749e-04 2.27824e-05
+       2014    24 -228.393332 -228.393395 6.371044e-05   0.371 9.38687e-05 2.42325e-05
+       2015    24 -228.393335 -228.393422 8.700715e-05   0.371 8.07458e-05 2.87483e-05
+       2016    24 -228.393339 -228.393439 1.008138e-04   0.371 6.52174e-05 3.33568e-05
+       2017    19 -228.393342 -228.393446 1.037980e-04   0.371 5.15022e-05 3.66191e-05
+       2018    19 -228.393345 -228.393441 9.629598e-05   0.371 4.49688e-05 3.80549e-05
+       2019    19 -228.393347 -228.393426 7.940340e-05   0.371 4.76800e-05 3.75997e-05
+       2020    19 -228.393348 -228.393403 5.545577e-05   0.371 5.52075e-05 3.54195e-05
+       2021    19 -228.393348 -228.393375 2.785882e-05   0.371 6.21560e-05 3.18837e-05
+       2022    21 -228.393347 -228.393346 3.590829e-07   0.371 6.58962e-05 2.75746e-05
+       2023    24 -228.393345 -228.393319 2.592509e-05   0.371 6.54967e-05 2.32834e-05
+       2024    23 -228.393343 -228.393297 4.574072e-05   0.371 6.17487e-05 1.99337e-05
+       2025    22 -228.393340 -228.393282 5.825633e-05   0.371 5.62290e-05 1.83074e-05
+       2026    24 -228.393337 -228.393275 6.240807e-05   0.371 5.08692e-05 1.85275e-05
+       2027    22 -228.393335 -228.393276 5.865767e-05   0.371 4.70726e-05 1.99511e-05
+       2028    24 -228.393333 -228.393285 4.801490e-05   0.371 4.49936e-05 2.17484e-05
+       2029    23 -228.393332 -228.393299 3.258121e-05   0.371 4.35370e-05 2.33146e-05
+       2030    19 -228.393332 -228.393317 1.504416e-05   0.371 4.13552e-05 2.42838e-05
+       2031    21 -228.393332 -228.393334 2.595319e-06   0.371 3.81870e-05 2.44514e-05
+       2032    20 -228.393333 -228.393350 1.772587e-05   0.371 3.42364e-05 2.37488e-05
+       2033    19 -228.393334 -228.393363 2.889802e-05   0.371 3.11047e-05 2.22304e-05
+       2034    21 -228.393336 -228.393370 3.473948e-05   0.371 3.02049e-05 2.00800e-05
+       2035    19 -228.393337 -228.393373 3.558787e-05   0.371 3.16888e-05 1.76225e-05
+       2036    22 -228.393339 -228.393370 3.146229e-05   0.371 3.43665e-05 1.53310e-05
+       2037    24 -228.393340 -228.393364 2.382707e-05   0.371 3.62707e-05 1.37737e-05
+       2038    23 -228.393340 -228.393355 1.418397e-05   0.371 3.64044e-05 1.33626e-05
+       2039    24 -228.393341 -228.393345 3.824761e-06   0.371 3.43777e-05 1.40021e-05
+       2040    24 -228.393341 -228.393336 5.152296e-06   0.371 3.03201e-05 1.51532e-05
+       2041    24 -228.393340 -228.393328 1.195196e-05   0.371 2.51378e-05 1.62505e-05
+       2042    19 -228.393340 -228.393324 1.550662e-05   0.371 2.01858e-05 1.69283e-05
+       2043    20 -228.393339 -228.393323 1.591678e-05   0.371 1.74266e-05 1.70267e-05
+       2044    20 -228.393338 -228.393325 1.281797e-05   0.371 1.77955e-05 1.65500e-05
+       2045    20 -228.393338 -228.393330 7.687359e-06   0.371 1.99784e-05 1.56193e-05
+       2046    22 -228.393337 -228.393336 7.195885e-07   0.371 2.22498e-05 1.44294e-05
+       2047    21 -228.393337 -228.393343 6.310788e-06   0.371 2.33719e-05 1.32130e-05
+       2048    22 -228.393337 -228.393349 1.270184e-05   0.371 2.33110e-05 1.21955e-05
+       2049    24 -228.393337 -228.393354 1.739597e-05   0.371 2.22317e-05 1.15394e-05
+       2050    19 -228.393337 -228.393357 1.979778e-05   0.371 2.07083e-05 1.12928e-05
+       2051    22 -228.393338 -228.393357 1.964252e-05   0.371 1.94140e-05 1.13789e-05
+       2052    24 -228.393338 -228.393355 1.703267e-05   0.371 1.85349e-05 1.16525e-05
+       2053    19 -228.393338 -228.393351 1.245068e-05   0.371 1.81039e-05 1.19656e-05
+       2054    21 -228.393339 -228.393345 6.486403e-06   0.371 1.77622e-05 1.22028e-05
+       2055    21 -228.393339 -228.393339 1.177449e-07   0.371 1.70349e-05 1.22912e-05
+       2056    21 -228.393339 -228.393332 6.037985e-06   0.371 1.59203e-05 1.21967e-05
+       2057    20 -228.393338 -228.393327 1.101570e-05   0.371 1.45270e-05 1.19202e-05
+       2058    19 -228.393338 -228.393324 1.435469e-05   0.371 1.33570e-05 1.14938e-05
+       2059    21 -228.393338 -228.393322 1.557844e-05   0.371 1.29151e-05 1.09802e-05
+       2060    20 -228.393337 -228.393322 1.478689e-05   0.371 1.33114e-05 1.04645e-05
+       2061    20 -228.393337 -228.393325 1.207069e-05   0.371 1.42583e-05 1.00358e-05
+       2062    22 -228.393337 -228.393329 7.941708e-06   0.371 1.51593e-05 9.76195e-06
+       2063    22 -228.393337 -228.393334 2.815030e-06   0.371 1.55324e-05 9.66404e-06
+       2064    22 -228.393337 -228.393339 2.609480e-06   0.371 1.52305e-05 9.70943e-06
+       2065    19 -228.393337 -228.393344 7.582641e-06   0.371 1.41528e-05 9.82925e-06
+       2066    22 -228.393337 -228.393349 1.181541e-05   0.371 1.26128e-05 9.94886e-06
+       2067    19 -228.393338 -228.393352 1.476136e-05   0.371 1.08162e-05 1.00114e-05
+       2068    20 -228.393338 -228.393354 1.613803e-05   0.371 9.33120e-06 9.98890e-06
+       2069    19 -228.393338 -228.393355 1.611251e-05   0.371 8.60008e-06 9.88208e-06
+       2070    19 -228.393339 -228.393353 1.453737e-05   0.371 8.75542e-06 9.71178e-06
+       2071    19 -228.393339 -228.393351 1.209077e-05   0.371 9.40818e-06 9.50998e-06
+       2072    19 -228.393339 -228.393348 8.636802e-06   0.371 1.01099e-05 9.30913e-06
+       2073    19 -228.393339 -228.393344 4.981618e-06   0.371 1.05144e-05 9.13430e-06
+       2074    19 -228.393339 -228.393340 1.314927e-06   0.371 1.05129e-05 8.99914e-06
+       2075    20 -228.393339 -228.393337 1.896271e-06   0.371 1.01109e-05 8.90637e-06
+       2076    21 -228.393338 -228.393334 4.405988e-06   0.371 9.40106e-06 8.85090e-06
+       2077    20 -228.393338 -228.393332 6.073560e-06   0.371 8.56590e-06 8.82393e-06
+       2078    19 -228.393338 -228.393331 6.794330e-06   0.371 7.77432e-06 8.81575e-06
+       2079    20 -228.393337 -228.393331 6.584435e-06   0.371 7.17513e-06 8.81703e-06
+       2080    19 -228.393337 -228.393331 5.594316e-06   0.371 6.80490e-06 8.81921e-06
+       2081    20 -228.393337 -228.393333 3.971152e-06   0.371 6.65736e-06 8.81431e-06
+       2082    19 -228.393337 -228.393335 2.030742e-06   0.371 6.57680e-06 8.79583e-06
+       2083    20 -228.393337 -228.393337 8.773597e-08   0.371 6.52196e-06 8.75898e-06
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization converged in   2 iterations 
+            Total energy change: -3.979039e-13
+            Final gradient norm: 4.482735e-07
+
+
+      v2RDM iterations converged!
+
+      v2RDM total spin [S(S+1)]:            -0.000001
+    * v2RDM total energy:           -228.393336650010
+
+
+ # Natural Orbital Occupation Numbers (alpha) #
+ Irrep: 1
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  1.0000000
+      6:  1.0000000
+      7:  1.0000000
+      8:  1.0000000
+      9:  1.0000000
+     10:  1.0000000
+     11:  1.0000000
+     12:  1.0000000
+     13:  1.0000000
+     14:  1.0000000
+     15:  1.0000000
+     16:  1.0000000
+     17:  1.0000000
+     18:  1.0000000
+     19:  0.5000006
+     20:  0.5000001
+     21:  0.5000000
+     22:  0.4999999
+     23:  0.4999999
+     24:  0.4999994
+     25:  0.0000000
+     26:  0.0000000
+     27:  0.0000000
+     28:  0.0000000
+     29:  0.0000000
+     30:  0.0000000
+     31:  0.0000000
+     32:  0.0000000
+     33:  0.0000000
+     34:  0.0000000
+     35:  0.0000000
+     36:  0.0000000
+
+
+ # Natural Orbital Occupation Numbers (beta) #
+ Irrep: 1
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  1.0000000
+      6:  1.0000000
+      7:  1.0000000
+      8:  1.0000000
+      9:  1.0000000
+     10:  1.0000000
+     11:  1.0000000
+     12:  1.0000000
+     13:  1.0000000
+     14:  1.0000000
+     15:  1.0000000
+     16:  1.0000000
+     17:  1.0000000
+     18:  1.0000000
+     19:  0.5000006
+     20:  0.5000001
+     21:  0.5000000
+     22:  0.4999999
+     23:  0.4999999
+     24:  0.4999994
+     25:  0.0000000
+     26:  0.0000000
+     27:  0.0000000
+     28:  0.0000000
+     29:  0.0000000
+     30:  0.0000000
+     31:  0.0000000
+     32:  0.0000000
+     33:  0.0000000
+     34:  0.0000000
+     35:  0.0000000
+     36:  0.0000000
+
+
+  ==> Iteration count <==
+
+      Microiterations:                   53145
+      Macroiterations:                    2084
+      Orbital optimization steps:            5
+
+  ==> Wall time <==
+
+      Microiterations:                   22.64 s
+      Macroiterations:                    4.50 s
+      Orbital optimization:              21.73 s
+      Total:                             50.05 s
+
+
+*** tstop() called on ed10 at Thu Jun 14 17:09:17 2018
+Module time:
+	user time   =      48.21 seconds =       0.80 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         50 seconds =       0.83 minutes
+Total time:
+	user time   =      51.83 seconds =       0.86 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =         54 seconds =       0.90 minutes
+
+*** tstart() called on ed10
+*** at Thu Jun 14 17:09:17 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-6  entry C          line    61 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+    atoms 7-12 entry H          line    19 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000000000000     1.389804000000     0.000000000000    12.000000000000
+         C            1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         C            1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C            0.000000000000    -1.389804000000     0.000000000000    12.000000000000
+         C           -1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         H           -0.000000000000     2.475234000000     0.000000000000     1.007825032070
+         H            2.143616000000     1.237617000000     0.000000000000     1.007825032070
+         H            2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H            0.000000000000    -2.475234000000     0.000000000000     1.007825032070
+         H           -2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -2.143616000000     1.237617000000     0.000000000000     1.007825032070
+
+  Running in d2h symmetry.
+
+  Rotational constants: A =      0.19143  B =      0.19143  C =      0.09572 [cm^-1]
+  Rotational constants: A =   5739.02343  B =   5739.01967  C =   2869.51077 [MHz]
+  Nuclear repulsion =  204.077021099348656
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 42
+  Nalpha       = 21
+  Nbeta        = 21
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 24
+    Number of basis function: 36
+    Number of Cartesian functions: 36
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         9       9       0       0       0       0
+     B1g        6       6       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         1       1       0       0       0       0
+     B1u        2       2       0       0       0       0
+     B2u        9       9       0       0       0       0
+     B3u        6       6       0       0       0       0
+   -------------------------------------------------------
+    Total      36      36      21      21      21       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                  12
+      Number of AO shells:              24
+      Number of primitives:             72
+      Number of atomic orbitals:        36
+      Number of basis functions:        36
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 444222 doubles for integral storage.
+  We computed 42486 shell quartets total.
+  Whereas there are 45150 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.6882920578E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -227.81707249348727   -2.27817e+02   2.26514e-01 
+   @RHF iter   1:  -227.76229457543462    5.47779e-02   2.42658e-02 
+   @RHF iter   2:  -227.88242405209746   -1.20129e-01   6.42494e-03 DIIS
+   @RHF iter   3:  -227.89087494235034   -8.45089e-03   1.57518e-03 DIIS
+   @RHF iter   4:  -227.89125016015723   -3.75218e-04   1.54668e-04 DIIS
+   @RHF iter   5:  -227.89125389414784   -3.73399e-06   2.12013e-05 DIIS
+   @RHF iter   6:  -227.89125401888199   -1.24734e-07   4.93124e-06 DIIS
+   @RHF iter   7:  -227.89125402703766   -8.15567e-09   1.36376e-06 DIIS
+   @RHF iter   8:  -227.89125402762633   -5.88670e-10   1.01238e-07 DIIS
+   @RHF iter   9:  -227.89125402762963   -3.29692e-12   8.95668e-09 DIIS
+   @RHF iter  10:  -227.89125402762943    1.98952e-13   9.28492e-10 DIIS
+   @RHF iter  11:  -227.89125402762926    1.70530e-13   8.36411e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1B2u  -11.029219     1B3u  -11.029219     1Ag   -11.029203  
+       2Ag   -11.028834     1B1g  -11.028834     2B2u  -11.028676  
+       3Ag    -1.093407     3B2u   -0.956555     2B3u   -0.956555  
+       4Ag    -0.767676     2B1g   -0.767676     5Ag    -0.663690  
+       4B2u   -0.592995     3B3u   -0.555650     5B2u   -0.534819  
+       4B3u   -0.534819     1B1u   -0.459063     6Ag    -0.433032  
+       3B1g   -0.433032     1B3g   -0.281537     1B2g   -0.281537  
+
+    Virtual:                                                              
+
+       1Au     0.270080     2B1u    0.270081     2B3g    0.507159  
+       7Ag     0.577151     5B3u    0.647784     6B2u    0.647785  
+       7B2u    0.724036     4B1g    0.739052     8Ag     0.739053  
+       5B1g    0.886660     9Ag     0.886661     6B3u    0.902363  
+       8B2u    0.902363     6B1g    1.094836     9B2u    1.158012  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     6,    3,    1,    1,    0,    1,    5,    4 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -227.89125402762926
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =            204.0770210993486558
+    One-Electron Energy =                -712.9644967008524645
+    Two-Electron Energy =                 280.9962215738745499
+    Total Energy =                       -227.8912540276292589
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on ed10 at Thu Jun 14 17:09:19 2018
+Module time:
+	user time   =       2.06 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      53.90 seconds =       0.90 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         56 seconds =       0.93 minutes
+
+*** tstart() called on ed10
+*** at Thu Jun 14 17:09:19 2018
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-6  entry C          line    61 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+    atoms 7-12 entry H          line    19 file /edfs/users/rainli/Software/psi4_20180521/psi4/install/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000000000000     1.389804000000     0.000000000000    12.000000000000
+         C            1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         C            1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C            0.000000000000    -1.389804000000     0.000000000000    12.000000000000
+         C           -1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         H           -0.000000000000     2.475234000000     0.000000000000     1.007825032070
+         H            2.143616000000     1.237617000000     0.000000000000     1.007825032070
+         H            2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H            0.000000000000    -2.475234000000     0.000000000000     1.007825032070
+         H           -2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -2.143616000000     1.237617000000     0.000000000000     1.007825032070
+
+  Running in d2h symmetry.
+
+  Rotational constants: A =      0.19143  B =      0.19143  C =      0.09572 [cm^-1]
+  Rotational constants: A =   5739.02343  B =   5739.01967  C =   2869.51077 [MHz]
+  Nuclear repulsion =  204.077021099348656
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 42
+  Nalpha       = 21
+  Nbeta        = 21
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 24
+    Number of basis function: 36
+    Number of Cartesian functions: 36
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         9       9       0       0       0       0
+     B1g        6       6       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         1       1       0       0       0       0
+     B1u        2       2       0       0       0       0
+     B2u        9       9       0       0       0       0
+     B3u        6       6       0       0       0       0
+   -------------------------------------------------------
+    Total      36      36      21      21      21       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                  12
+      Number of AO shells:              24
+      Number of primitives:             72
+      Number of atomic orbitals:        36
+      Number of basis functions:        36
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 444222 doubles for integral storage.
+  We computed 42486 shell quartets total.
+  Whereas there are 45150 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.6882920578E-01.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:  -227.81707249348727   -2.27817e+02   2.26514e-01 
+   @RHF iter   1:  -227.76229457543445    5.47779e-02   2.42658e-02 
+   @RHF iter   2:  -227.88242405209755   -1.20129e-01   6.42494e-03 DIIS
+   @RHF iter   3:  -227.89087494235031   -8.45089e-03   1.57518e-03 DIIS
+   @RHF iter   4:  -227.89125016015728   -3.75218e-04   1.54668e-04 DIIS
+   @RHF iter   5:  -227.89125389414789   -3.73399e-06   2.12013e-05 DIIS
+   @RHF iter   6:  -227.89125401888208   -1.24734e-07   4.93124e-06 DIIS
+   @RHF iter   7:  -227.89125402703777   -8.15569e-09   1.36376e-06 DIIS
+   @RHF iter   8:  -227.89125402762591   -5.88130e-10   1.01238e-07 DIIS
+   @RHF iter   9:  -227.89125402762934   -3.43903e-12   8.95668e-09 DIIS
+   @RHF iter  10:  -227.89125402762954   -1.98952e-13   9.28490e-10 DIIS
+   @RHF iter  11:  -227.89125402762951    2.84217e-14   8.36412e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1B2u  -11.029219     1B3u  -11.029219     1Ag   -11.029203  
+       2Ag   -11.028834     1B1g  -11.028834     2B2u  -11.028676  
+       3Ag    -1.093407     3B2u   -0.956555     2B3u   -0.956555  
+       4Ag    -0.767676     2B1g   -0.767676     5Ag    -0.663690  
+       4B2u   -0.592995     3B3u   -0.555650     5B2u   -0.534819  
+       4B3u   -0.534819     1B1u   -0.459063     6Ag    -0.433032  
+       3B1g   -0.433032     1B3g   -0.281537     1B2g   -0.281537  
+
+    Virtual:                                                              
+
+       1Au     0.270080     2B1u    0.270081     2B3g    0.507159  
+       7Ag     0.577151     5B3u    0.647784     6B2u    0.647785  
+       7B2u    0.724036     4B1g    0.739052     8Ag     0.739053  
+       5B1g    0.886660     9Ag     0.886661     6B3u    0.902363  
+       8B2u    0.902363     6B1g    1.094836     9B2u    1.158012  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     6,    3,    1,    1,    0,    1,    5,    4 ]
+
+  Energy converged.
+
+  @RHF Final Energy:  -227.89125402762951
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =            204.0770210993486558
+    One-Electron Energy =                -712.9644967008536014
+    Two-Electron Energy =                 280.9962215738754026
+    Total Energy =                       -227.8912540276295431
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on ed10 at Thu Jun 14 17:09:21 2018
+Module time:
+	user time   =       2.03 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      55.94 seconds =       0.93 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =         58 seconds =       0.97 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                  12
+      Number of AO shells:              24
+      Number of SO shells:               8
+      Number of primitives:             72
+      Number of atomic orbitals:        36
+      Number of basis functions:        36
+
+      Number of irreps:                  8
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [   9    6    1    2    1    2    9    6 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 34187 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+Reading options from the V2RDM_CASSCF block
+Calling plugin v2rdm_casscf.so.
+
+
+
+*** tstart() called on ed10
+*** at Thu Jun 14 17:09:22 2018
+
+
+
+        ****************************************************
+        *                                                  *
+        *    v2RDM-CASSCF                                  *
+        *                                                  *
+        *    A variational 2-RDM-driven approach to the    *
+        *    active space self-consistent field method     *
+        *                                                  *
+        ****************************************************
+
+
+        The following papers should be cited when using v2RDM-CASSCF:
+
+        J. Fosso-Tande, D. R. Nascimento, and A. E. DePrince III,
+        Mol. Phys. 114, 423-430 (2015).
+
+            URL: http://dx.doi.org/10.1080/00268976.2015.1078008
+
+        J. Fosso-Tande, T.-S. Nguyen, G. Gidofalvi, and
+        A. E. DePrince III, J. Chem. Theory Comput. accepted (2016).
+
+            URL: http://dx.doi.org/10.1021/acs.jctc.6b00190
+
+
+
+  ==> Convergence parameters <==
+
+        r_convergence:                      1.000e-05
+        e_convergence:                      1.000e-06
+        cg_convergence:                     1.000e-09
+        maxiter:                                20000
+        cg_maxiter:                             10000
+
+  ==> Active space details <==
+
+        Number of frozen core orbitals:             0
+        Number of restricted occupied orbitals:    18
+        Number of active occupied orbitals:         3
+        Number of active virtual orbitals:          3
+        Number of restricted virtual orbitals:     12
+        Number of frozen virtual orbitals:          0
+
+        Irrep:             Ag, B1g, B2g, B3g,  Au, B1u, B2u, B3u 
+ 
+        frozen_docc     [   0,   0,   0,   0,   0,   0,   0,   0 ]
+        restricted_docc [   6,   3,   0,   0,   0,   0,   5,   4 ]
+        active          [   0,   0,   1,   2,   1,   2,   0,   0 ]
+        restricted_uocc [   3,   3,   0,   0,   0,   0,   4,   2 ]
+        frozen_uocc     [   0,   0,   0,   0,   0,   0,   0,   0 ]
+
+  ==> Orbital optimization parameters <==
+
+        1-step algorithm:                    true
+        g_convergence:                  1.000e-06
+        e_convergence:                  1.000e-08
+        maximum iterations:                    20
+        frequency:                            500
+        active-active rotations:            false
+        exact diagonal Hessian:             false
+        number of DIIS vectors:                 0
+        print iteration info:               false
+
+  ==> Memory requirements <==
+
+        D2:                          0.00 mb
+        Q2:                          0.00 mb
+
+        Total number of variables:           1268
+        Total number of constraints:         1035
+        Total memory requirements:        0.39 mb
+
+    ==> Transform two-electron integrals <==
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+        Time for integral transformation:     0.07 s
+
+    Molecular point group: d2h
+    Full point group: D2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000000000000     1.389804000000     0.000000000000    12.000000000000
+         C            1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         C            1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C            0.000000000000    -1.389804000000     0.000000000000    12.000000000000
+         C           -1.203605000000    -0.694902000000     0.000000000000    12.000000000000
+         C           -1.203605000000     0.694902000000     0.000000000000    12.000000000000
+         H           -0.000000000000     2.475234000000     0.000000000000     1.007825032070
+         H            2.143616000000     1.237617000000     0.000000000000     1.007825032070
+         H            2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H            0.000000000000    -2.475234000000     0.000000000000     1.007825032070
+         H           -2.143616000000    -1.237617000000     0.000000000000     1.007825032070
+         H           -2.143616000000     1.237617000000     0.000000000000     1.007825032070
+
+  -AO BASIS SET INFORMATION:
+    Name                   = STO-3G
+    Blend                  = STO-3G
+    Total number of shells = 24
+    Number of primitives   = 72
+    Number of AO           = 36
+    Number of SO           = 36
+    Maximum AM             = 1
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     C     6s 3p // 2s 1p 
+       2     C     6s 3p // 2s 1p 
+       3     C     6s 3p // 2s 1p 
+       4     C     6s 3p // 2s 1p 
+       5     C     6s 3p // 2s 1p 
+       6     C     6s 3p // 2s 1p 
+       7     H     3s // 1s 
+       8     H     3s // 1s 
+       9     H     3s // 1s 
+      10     H     3s // 1s 
+      11     H     3s // 1s 
+      12     H     3s // 1s 
+
+  ==> AO Basis Functions <==
+
+    [ STO-3G ]
+    spherical
+    ****
+    C   1
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    C   2
+    S   3 1.00
+                        71.61683700           0.15432897
+                        13.04509600           0.53532814
+                         3.53051220           0.44463454
+    S   3 1.00
+                         2.94124940          -0.09996723
+                         0.68348310           0.39951283
+                         0.22228990           0.70011547
+    P   3 1.00
+                         2.94124940           0.15591627
+                         0.68348310           0.60768372
+                         0.22228990           0.39195739
+    ****
+    H   7
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+    H   8
+    S   3 1.00
+                         3.42525091           0.15432897
+                         0.62391373           0.53532814
+                         0.16885540           0.44463454
+    ****
+
+
+        Read integrals......done.
+
+
+    reference energy:        -227.891254027630
+    frozen core energy:      -425.600751369267
+    initial 2-RDM energy:    -221.315166481645
+
+      oiter iiter        E(p)        E(d)      E gap)      mu     eps(p)     eps(d)
+          0    45 -224.963008  -49.171788 1.757912e+02   1.000 1.36374e+02 7.54660e+01
+          1    28 -220.529320 -461.530807 2.410015e+02   1.000 1.29673e+01 4.94481e+01
+          2    27 -225.640557 -295.585221 6.994466e+01   1.000 1.32910e+01 3.08300e+00
+          3    26 -230.389901 -275.161099 4.477120e+01   1.000 1.19504e+01 2.40080e+00
+          4    27 -229.585920 -260.578752 3.099283e+01   1.000 9.72262e+00 1.96574e+00
+          5    28 -228.940807 -248.132048 1.919124e+01   1.000 7.06558e+00 1.88502e+00
+          6    28 -228.374658 -240.083560 1.170890e+01   1.000 5.47758e+00 1.53354e+00
+          7    28 -227.934648 -233.460863 5.526216e+00   1.000 3.77378e+00 1.40063e+00
+          8    28 -227.559152 -230.310191 2.751039e+00   1.000 3.10979e+00 1.37028e+00
+          9    26 -227.673591 -228.074789 4.011984e-01   1.000 2.86054e+00 1.10044e+00
+         10    26 -227.588649 -226.843057 7.455927e-01   1.000 1.96431e+00 1.38029e+00
+         11    23 -227.656272 -227.008213 6.480590e-01   1.000 9.14397e-01 9.93570e-01
+         12    25 -227.888329 -227.220614 6.677142e-01   1.000 7.66289e-01 6.78231e-01
+         13    23 -227.920446 -227.064223 8.562230e-01   1.000 2.87483e-01 5.39992e-01
+         14    27 -228.027644 -227.544716 4.829280e-01   1.000 2.36891e-01 4.12191e-01
+         15    23 -228.059193 -227.785332 2.738617e-01   1.000 3.20890e-01 3.39355e-01
+         16    21 -228.063484 -228.041317 2.216660e-02   1.000 3.70646e-01 2.49446e-01
+         17    23 -228.097896 -228.275236 1.773398e-01   1.000 2.40300e-01 1.74822e-01
+         18    23 -228.133485 -228.242169 1.086840e-01   1.000 1.36010e-01 1.47260e-01
+         19    26 -228.147013 -228.112552 3.446117e-02   1.000 1.08282e-01 1.41466e-01
+         20    24 -228.150267 -228.052336 9.793104e-02   1.000 7.50373e-02 1.41318e-01
+         21    22 -228.154617 -228.062860 9.175704e-02   1.000 6.69257e-02 1.24929e-01
+         22    21 -228.164294 -228.093935 7.035880e-02   1.000 6.82296e-02 1.02159e-01
+         23    23 -228.177365 -228.105759 7.160578e-02   1.000 5.83958e-02 8.87400e-02
+         24    23 -228.190215 -228.099142 9.107283e-02   1.000 4.08421e-02 8.72777e-02
+         25    21 -228.201154 -228.091629 1.095250e-01   1.000 2.63028e-02 8.74140e-02
+         26    21 -228.205777 -228.094582 1.111947e-01   1.000 3.37697e-02 7.36396e-02
+         27    20 -228.211894 -228.140084 7.181058e-02   1.000 3.84613e-02 5.99799e-02
+         28    24 -228.217705 -228.173793 4.391197e-02   1.000 3.56089e-02 5.09792e-02
+         29    24 -228.220284 -228.177399 4.288470e-02   1.000 3.13908e-02 4.76362e-02
+         30    23 -228.220700 -228.176808 4.389215e-02   1.000 2.41827e-02 4.81860e-02
+         31    21 -228.219787 -228.176718 4.306926e-02   1.000 1.74896e-02 4.84735e-02
+         32    21 -228.218142 -228.178196 3.994616e-02   1.000 1.46677e-02 4.70379e-02
+         33    22 -228.216790 -228.178496 3.829340e-02   1.000 1.38624e-02 4.47967e-02
+         34    22 -228.215702 -228.176429 3.927271e-02   1.000 1.25405e-02 4.29450e-02
+         35    23 -228.215420 -228.173302 4.211831e-02   1.000 1.11971e-02 4.17943e-02
+         36    23 -228.216000 -228.170614 4.538615e-02   1.000 1.08842e-02 4.10325e-02
+         37    24 -228.217402 -228.169063 4.833845e-02   1.000 1.12256e-02 4.04419e-02
+         38    21 -228.219523 -228.168419 5.110430e-02   1.000 1.08484e-02 4.00554e-02
+         39    22 -228.222128 -228.168570 5.355739e-02   1.000 9.37248e-03 3.98823e-02
+         40    22 -228.225015 -228.169145 5.586983e-02   1.000 7.01335e-03 3.97700e-02
+         41    22 -228.227865 -228.170026 5.783905e-02   1.000 4.85628e-03 3.95449e-02
+         42    22 -228.230568 -228.171012 5.955557e-02   1.000 3.96549e-03 3.91844e-02
+         43    21 -228.232930 -228.172010 6.092007e-02   1.000 4.31381e-03 3.88097e-02
+         44    24 -228.234921 -228.172930 6.199121e-02   1.000 4.63510e-03 3.85481e-02
+         45    21 -228.236547 -228.173816 6.273060e-02   1.000 4.42339e-03 3.84247e-02
+         46    22 -228.237843 -228.174562 6.328168e-02   1.000 3.82592e-03 3.83726e-02
+         47    22 -228.238931 -228.175188 6.374272e-02   1.000 3.19541e-03 3.83125e-02
+         48    22 -228.239896 -228.175633 6.426309e-02   1.000 2.79182e-03 3.82115e-02
+         49    22 -228.240846 -228.175866 6.498059e-02   1.000 2.64457e-03 3.80843e-02
+         50    22 -228.241850 -228.175871 6.597877e-02   1.000 2.55331e-03 3.79604e-02
+         51    22 -228.242967 -228.175721 6.724642e-02   1.000 2.38798e-03 3.78582e-02
+         52    22 -228.244229 -228.175500 6.872889e-02   1.000 2.14021e-03 3.77786e-02
+         53    21 -228.245621 -228.175292 7.032884e-02   1.000 1.83126e-03 3.77133e-02
+         54    21 -228.247126 -228.175162 7.196395e-02   1.000 1.50797e-03 3.76540e-02
+         55    24 -228.248708 -228.175159 7.354877e-02   1.000 1.21531e-03 3.75952e-02
+         56    23 -228.249759 -228.175290 7.446903e-02   1.000 3.51567e-03 3.71082e-02
+         57    20 -228.247691 -228.176923 7.076799e-02   1.000 2.40527e-02 3.37187e-02
+         58    20 -228.249803 -228.195487 5.431524e-02   1.000 2.09276e-02 3.26158e-02
+         59    18 -228.252185 -228.204141 4.804344e-02   1.000 1.13026e-02 3.24685e-02
+         60    18 -228.254727 -228.203447 5.127974e-02   1.000 4.34418e-03 3.21579e-02
+         61    23 -228.256027 -228.197690 5.833627e-02   1.000 4.91681e-03 3.18236e-02
+         62    21 -228.256575 -228.194138 6.243720e-02   1.000 3.00916e-03 3.16810e-02
+         63    21 -228.256959 -228.194156 6.280317e-02   1.000 3.56271e-03 3.15849e-02
+         64    20 -228.257631 -228.196254 6.137738e-02   1.000 5.46857e-03 3.14641e-02
+         65    19 -228.258555 -228.198198 6.035682e-02   1.000 5.71798e-03 3.13424e-02
+         66    19 -228.259668 -228.199152 6.051595e-02   1.000 4.93085e-03 3.12281e-02
+         67    19 -228.260724 -228.199268 6.145612e-02   1.000 4.09916e-03 3.11190e-02
+         68    19 -228.261773 -228.199143 6.262948e-02   1.000 3.59457e-03 3.10199e-02
+         69    20 -228.262768 -228.199179 6.358830e-02   1.000 3.25124e-03 3.09387e-02
+         70    22 -228.263873 -228.199918 6.395532e-02   1.000 2.61536e-03 3.08505e-02
+         71    22 -228.264914 -228.200228 6.468578e-02   1.000 2.17893e-03 3.07691e-02
+         72    22 -228.265924 -228.200303 6.562114e-02   1.000 1.95494e-03 3.06925e-02
+         73    22 -228.266893 -228.200462 6.643112e-02   1.000 1.77207e-03 3.06253e-02
+         74    22 -228.267929 -228.201184 6.674527e-02   1.000 1.40350e-03 3.05490e-02
+         75    23 -228.268910 -228.201590 6.732030e-02   1.000 1.10165e-03 3.04782e-02
+         76    22 -228.269868 -228.201766 6.810255e-02   1.000 9.59194e-04 3.04130e-02
+         77    22 -228.270774 -228.201854 6.891929e-02   1.000 9.43050e-04 3.03522e-02
+         78    23 -228.271669 -228.202077 6.959216e-02   1.000 9.96923e-04 3.02949e-02
+         79    22 -228.272565 -228.202377 7.018798e-02   1.000 1.03810e-03 3.02403e-02
+         80    22 -228.273470 -228.202684 7.078540e-02   1.000 1.04037e-03 3.01881e-02
+         81    22 -228.274376 -228.202952 7.142382e-02   1.000 1.01754e-03 3.01380e-02
+         82    22 -228.275278 -228.203192 7.208656e-02   1.000 1.00504e-03 3.00902e-02
+         83    22 -228.275435 -228.203416 7.201894e-02   1.000 4.99399e-03 2.96844e-02
+         84    22 -228.275768 -228.207241 6.852762e-02   1.000 8.83043e-03 2.92700e-02
+         85    18 -228.277037 -228.212520 6.451708e-02   1.000 7.92830e-03 2.89812e-02
+         86    19 -228.277241 -228.214695 6.254655e-02   1.000 1.07371e-02 2.82518e-02
+         87    19 -228.278397 -228.220475 5.792182e-02   1.000 9.35230e-03 2.79464e-02
+         88    19 -228.279933 -228.224025 5.590732e-02   1.000 5.52151e-03 2.79183e-02
+         89    22 -228.281388 -228.224373 5.701574e-02   1.000 3.50548e-03 2.78273e-02
+         90    22 -228.282372 -228.222895 5.947743e-02   1.000 3.44656e-03 2.77160e-02
+         91    22 -228.283043 -228.221440 6.160220e-02   1.000 2.95565e-03 2.76023e-02
+         92    22 -228.283497 -228.220711 6.278681e-02   1.000 1.89094e-03 2.75075e-02
+         93    22 -228.283946 -228.220703 6.324254e-02   1.000 1.39913e-03 2.74268e-02
+         94    23 -228.284462 -228.221100 6.336206e-02   1.000 1.92445e-03 2.73410e-02
+         95    22 -228.285163 -228.221845 6.331825e-02   1.000 2.33968e-03 2.72521e-02
+         96    20 -228.285951 -228.222370 6.358098e-02   1.000 2.60026e-03 2.71658e-02
+         97    22 -228.286796 -228.222544 6.425111e-02   1.000 2.84760e-03 2.70870e-02
+         98    19 -228.287627 -228.222478 6.514851e-02   1.000 3.03349e-03 2.70194e-02
+         99    20 -228.288405 -228.222376 6.602900e-02   1.000 3.05907e-03 2.69643e-02
+        100    20 -228.289150 -228.222393 6.675718e-02   1.000 2.97739e-03 2.69208e-02
+        101    19 -228.289871 -228.222566 6.730470e-02   1.000 2.84551e-03 2.68874e-02
+        102    20 -228.290586 -228.222817 6.776925e-02   1.000 2.67708e-03 2.68620e-02
+        103    20 -228.291302 -228.223060 6.824180e-02   1.000 2.46193e-03 2.68420e-02
+        104    20 -228.292016 -228.223236 6.878019e-02   1.000 2.20300e-03 2.68247e-02
+        105    20 -228.292727 -228.223338 6.938876e-02   1.000 1.91376e-03 2.68075e-02
+        106    20 -228.293428 -228.223396 7.003244e-02   1.000 1.60861e-03 2.67888e-02
+        107    20 -228.294127 -228.223446 7.068154e-02   1.000 1.30804e-03 2.67675e-02
+        108    20 -228.294824 -228.223514 7.131065e-02   1.000 1.04337e-03 2.67436e-02
+        109    24 -228.295525 -228.223602 7.192300e-02   1.000 8.57518e-04 2.67172e-02
+        110    22 -228.296226 -228.223696 7.253021e-02   1.000 7.90071e-04 2.66893e-02
+        111    23 -228.296931 -228.223785 7.314574e-02   1.000 8.32134e-04 2.66606e-02
+        112    22 -228.297642 -228.223864 7.377818e-02   1.000 9.33343e-04 2.66323e-02
+        113    23 -228.298349 -228.223934 7.441539e-02   1.000 1.04723e-03 2.66053e-02
+        114    20 -228.299057 -228.223994 7.506282e-02   1.000 1.14534e-03 2.65803e-02
+        115    20 -228.299767 -228.224054 7.571236e-02   1.000 1.21169e-03 2.65578e-02
+        116    21 -228.300474 -228.224117 7.635666e-02   1.000 1.24258e-03 2.65378e-02
+        117    23 -228.301181 -228.224181 7.700040e-02   1.000 1.23592e-03 2.65203e-02
+        118    21 -228.301888 -228.224246 7.764147e-02   1.000 1.19595e-03 2.65049e-02
+        119    23 -228.302592 -228.224308 7.828407e-02   1.000 1.12373e-03 2.64911e-02
+        120    20 -228.303296 -228.224367 7.892921e-02   1.000 1.02973e-03 2.64784e-02
+        121    22 -228.304000 -228.224422 7.957791e-02   1.000 9.16505e-04 2.64663e-02
+        122    21 -228.304700 -228.224472 8.022749e-02   1.000 7.95874e-04 2.64544e-02
+        123    21 -228.305402 -228.224518 8.088425e-02   1.000 6.74535e-04 2.64424e-02
+        124    23 -228.306103 -228.224563 8.154016e-02   1.000 5.63554e-04 2.64302e-02
+        125    19 -228.306800 -228.224603 8.219773e-02   1.000 4.76336e-04 2.64177e-02
+        126    23 -228.307501 -228.224643 8.285772e-02   1.000 4.19669e-04 2.64051e-02
+        127    23 -228.308200 -228.224682 8.351751e-02   1.000 4.04506e-04 2.63923e-02
+        128    23 -228.308897 -228.224719 8.417811e-02   1.000 4.19926e-04 2.63797e-02
+        129    23 -228.309597 -228.224754 8.484266e-02   1.000 4.53018e-04 2.63672e-02
+        130    23 -228.310289 -228.224788 8.550130e-02   1.000 4.89804e-04 2.63551e-02
+        131    23 -228.310988 -228.224820 8.616804e-02   1.000 5.20977e-04 2.63435e-02
+        132    23 -228.311682 -228.224852 8.682973e-02   1.000 5.42516e-04 2.63324e-02
+        133    23 -228.312375 -228.224882 8.749295e-02   1.000 5.52896e-04 2.63217e-02
+        134    19 -228.313068 -228.224910 8.815746e-02   1.000 5.51507e-04 2.63115e-02
+        135    22 -228.313760 -228.224938 8.882181e-02   1.000 5.38720e-04 2.63018e-02
+        136    19 -228.314451 -228.224965 8.948534e-02   1.000 5.18141e-04 2.62923e-02
+        137    22 -228.315142 -228.224991 9.015085e-02   1.000 4.90066e-04 2.62831e-02
+        138    19 -228.315831 -228.225017 9.081411e-02   1.000 4.58959e-04 2.62741e-02
+        139    21 -228.316521 -228.225041 9.147939e-02   1.000 4.25311e-04 2.62653e-02
+        140    19 -228.317210 -228.225066 9.214364e-02   1.000 3.94047e-04 2.62565e-02
+        141    23 -228.317899 -228.225092 9.280761e-02   1.000 3.64572e-04 2.62479e-02
+        142    18 -228.318586 -228.225115 9.347095e-02   1.000 3.42007e-04 2.62393e-02
+        143    22 -228.319276 -228.225139 9.413613e-02   1.000 3.22664e-04 2.62308e-02
+        144    23 -228.319962 -228.225164 9.479862e-02   1.000 3.11181e-04 2.62225e-02
+        145    22 -228.320648 -228.225187 9.546133e-02   1.000 3.03235e-04 2.62143e-02
+        146    23 -228.321337 -228.225210 9.612706e-02   1.000 2.98781e-04 2.62062e-02
+        147    22 -228.322021 -228.225234 9.678734e-02   1.000 2.96479e-04 2.61982e-02
+        148    23 -228.322709 -228.225256 9.745246e-02   1.000 2.94347e-04 2.61905e-02
+        149    22 -228.323393 -228.225280 9.811361e-02   1.000 2.92399e-04 2.61828e-02
+        150    23 -228.324079 -228.225302 9.877677e-02   1.000 2.89357e-04 2.61754e-02
+        151    22 -228.324766 -228.225338 9.942842e-02   1.000 2.88305e-04 2.61681e-02
+        152    23 -228.325452 -228.225364 1.000884e-01   1.000 2.86532e-04 2.61609e-02
+        153    20 -228.326137 -228.225377 1.007608e-01   1.000 2.81896e-04 2.61538e-02
+        154    23 -228.326821 -228.225389 1.014319e-01   1.000 2.75640e-04 2.61468e-02
+        155    23 -228.327503 -228.225407 1.020957e-01   1.000 2.70604e-04 2.61400e-02
+        156    23 -228.328186 -228.225430 1.027552e-01   1.000 2.66019e-04 2.61332e-02
+        157    23 -228.328869 -228.225456 1.034132e-01   1.000 2.62645e-04 2.61265e-02
+        158    23 -228.329552 -228.225480 1.040715e-01   1.000 2.59970e-04 2.61200e-02
+        159    23 -228.330236 -228.225512 1.047238e-01   1.000 2.61981e-04 2.61135e-02
+        160    24 -228.330920 -228.225541 1.053787e-01   1.000 2.65990e-04 2.61071e-02
+        161    23 -228.331603 -228.225558 1.060452e-01   1.000 2.67063e-04 2.61007e-02
+        162    23 -228.332283 -228.225569 1.067138e-01   1.000 2.64923e-04 2.60944e-02
+        163    21 -228.332963 -228.225583 1.073801e-01   1.000 2.61503e-04 2.60883e-02
+        164    22 -228.333642 -228.225604 1.080382e-01   1.000 2.58129e-04 2.60821e-02
+        165    23 -228.334321 -228.225629 1.086927e-01   1.000 2.56156e-04 2.60761e-02
+        166    19 -228.335002 -228.225654 1.093479e-01   1.000 2.54889e-04 2.60701e-02
+        167    23 -228.335681 -228.225678 1.100023e-01   1.000 2.53226e-04 2.60642e-02
+        168    19 -228.336361 -228.225701 1.106603e-01   1.000 2.51838e-04 2.60584e-02
+        169    22 -228.337039 -228.225721 1.113172e-01   1.000 2.48986e-04 2.60526e-02
+        170    22 -228.337717 -228.225743 1.119737e-01   1.000 2.46746e-04 2.60469e-02
+        171    22 -228.338395 -228.225765 1.126293e-01   1.000 2.43768e-04 2.60413e-02
+        172    22 -228.339072 -228.225788 1.132836e-01   1.000 2.41369e-04 2.60357e-02
+        173    23 -228.339749 -228.225811 1.139381e-01   1.000 2.38694e-04 2.60302e-02
+        174    22 -228.340425 -228.225834 1.145907e-01   1.000 2.36636e-04 2.60247e-02
+        175    22 -228.341102 -228.225857 1.152451e-01   1.000 2.34221e-04 2.60193e-02
+        176    22 -228.341778 -228.225881 1.158976e-01   1.000 2.31923e-04 2.60139e-02
+        177    24 -228.342454 -228.225904 1.165504e-01   1.000 2.29568e-04 2.60086e-02
+        178    21 -228.343129 -228.225927 1.172024e-01   1.000 2.27742e-04 2.60033e-02
+        179    22 -228.343804 -228.225950 1.178538e-01   1.000 2.25930e-04 2.59981e-02
+        180    22 -228.343271 -228.225974 1.172964e-01   1.000 4.36886e-03 2.50719e-02
+        181    16 -228.337232 -228.233831 1.034006e-01   1.000 2.94436e-02 2.16114e-02
+        182    20 -228.336660 -228.280401 5.625984e-02   1.000 3.61268e-02 1.84257e-02
+        183    20 -228.339377 -228.312513 2.686404e-02   1.000 3.02982e-02 1.84649e-02
+        184    18 -228.343194 -228.323140 2.005315e-02   1.000 1.76584e-02 1.91359e-02
+        185    16 -228.346616 -228.318817 2.779842e-02   1.000 4.74951e-03 1.91940e-02
+        186    24 -228.349008 -228.308771 4.023706e-02   1.000 1.16918e-02 1.85701e-02
+        187    17 -228.350028 -228.298365 5.166279e-02   1.000 1.81306e-02 1.78976e-02
+        188    15 -228.349897 -228.289315 6.058142e-02   1.000 1.76817e-02 1.77222e-02
+        189    15 -228.348952 -228.282111 6.684191e-02   1.000 1.17997e-02 1.78970e-02
+        190    15 -228.347758 -228.277804 6.995443e-02   1.000 3.69452e-03 1.79977e-02
+        191    19 -228.346828 -228.277818 6.900958e-02   1.000 4.76390e-03 1.78934e-02
+        192    17 -228.346474 -228.282091 6.438292e-02   1.000 9.34411e-03 1.77148e-02
+        193    15 -228.346796 -228.288792 5.800410e-02   1.000 1.01904e-02 1.76139e-02
+        194    15 -228.347651 -228.295239 5.241248e-02   1.000 7.66252e-03 1.76256e-02
+        195    15 -228.348753 -228.299126 4.962673e-02   1.000 3.23019e-03 1.76727e-02
+        196    17 -228.349781 -228.299448 5.033307e-02   1.000 1.58214e-03 1.76718e-02
+        197    18 -228.350527 -228.296821 5.370593e-02   1.000 4.69888e-03 1.76194e-02
+        198    15 -228.350918 -228.292841 5.807695e-02   1.000 5.76523e-03 1.75713e-02
+        199    14 -228.351013 -228.289143 6.186966e-02   1.000 4.79106e-03 1.75640e-02
+        200    15 -228.350942 -228.286860 6.408179e-02   1.000 2.48888e-03 1.75809e-02
+        201    17 -228.350861 -228.286404 6.445706e-02   1.000 2.83584e-04 1.75867e-02
+        202    20 -228.350888 -228.287519 6.336914e-02   1.000 2.22462e-03 1.75714e-02
+        203    15 -228.351082 -228.289501 6.158110e-02   1.000 3.14983e-03 1.75523e-02
+        204    15 -228.351445 -228.291562 5.988333e-02   1.000 2.88424e-03 1.75458e-02
+        205    15 -228.351925 -228.293054 5.887074e-02   1.000 1.74661e-03 1.75499e-02
+        206    15 -228.352447 -228.293627 5.882047e-02   1.000 2.91458e-04 1.75525e-02
+        207    21 -228.352938 -228.293276 5.966198e-02   1.000 1.00210e-03 1.75480e-02
+        208    16 -228.353349 -228.292297 6.105134e-02   1.000 1.69602e-03 1.75409e-02
+        209    15 -228.353660 -228.291124 6.253670e-02   1.000 1.71464e-03 1.75370e-02
+        210    15 -228.353892 -228.290167 6.372460e-02   1.000 1.18468e-03 1.75370e-02
+        211    15 -228.354081 -228.289694 6.438697e-02   1.000 3.91174e-04 1.75375e-02
+        212    18 -228.354273 -228.289763 6.450937e-02   1.000 3.86035e-04 1.75359e-02
+        213    20 -228.354504 -228.290248 6.425554e-02   1.000 8.64865e-04 1.75331e-02
+        214    16 -228.354791 -228.290909 6.388222e-02   1.000 9.73136e-04 1.75309e-02
+        215    16 -228.355130 -228.291500 6.363017e-02   1.000 7.49473e-04 1.75301e-02
+        216    17 -228.355501 -228.291850 6.365168e-02   1.000 3.33765e-04 1.75298e-02
+        217    18 -228.355878 -228.291893 6.398445e-02   1.000 1.40831e-04 1.75289e-02
+        218    21 -228.356236 -228.291679 6.455655e-02   1.000 4.42869e-04 1.75276e-02
+        219    16 -228.356564 -228.291331 6.523328e-02   1.000 5.58124e-04 1.75263e-02
+        220    16 -228.356860 -228.290987 6.587230e-02   1.000 4.78383e-04 1.75255e-02
+        221    17 -228.357134 -228.290757 6.637724e-02   1.000 2.68104e-04 1.75249e-02
+        222    20 -228.357401 -228.290693 6.670782e-02   1.000 6.80248e-05 1.75243e-02
+        223    22 -228.357676 -228.290784 6.689159e-02   1.000 2.05796e-04 1.75235e-02
+        224    20 -228.357966 -228.290972 6.699363e-02   1.000 2.98728e-04 1.75227e-02
+        225    18 -228.358275 -228.291177 6.709832e-02   1.000 2.81265e-04 1.75220e-02
+        226    19 -228.358599 -228.291332 6.726725e-02   1.000 1.81200e-04 1.75215e-02
+        227    20 -228.358928 -228.291399 6.752942e-02   1.000 6.85516e-05 1.75209e-02
+        228    21 -228.359255 -228.291373 6.788208e-02   1.000 1.10811e-04 1.75203e-02
+        229    21 -228.359573 -228.291284 6.828950e-02   1.000 1.73660e-04 1.75198e-02
+        230    20 -228.359881 -228.291174 6.870762e-02   1.000 1.78741e-04 1.75192e-02
+        231    20 -228.360181 -228.291083 6.909737e-02   1.000 1.33835e-04 1.75187e-02
+        232    21 -228.360475 -228.291038 6.943727e-02   1.000 7.23686e-05 1.75183e-02
+        233    20 -228.360771 -228.291046 6.972518e-02   1.000 6.21847e-05 1.75178e-02
+        234    23 -228.361070 -228.291093 6.997647e-02   1.000 9.34759e-05 1.75174e-02
+        235    21 -228.361375 -228.291159 7.021579e-02   1.000 1.03235e-04 1.75169e-02
+        236    22 -228.361685 -228.291219 7.046580e-02   1.000 8.60877e-05 1.75165e-02
+        237    22 -228.361998 -228.291256 7.074194e-02   1.000 5.93247e-05 1.75161e-02
+        238    23 -228.362312 -228.291264 7.104774e-02   1.000 5.32040e-05 1.75157e-02
+        239    23 -228.362623 -228.291247 7.137654e-02   1.000 6.75127e-05 1.75154e-02
+        240    22 -228.362932 -228.291216 7.171571e-02   1.000 7.52383e-05 1.75150e-02
+        241    21 -228.363237 -228.291186 7.205159e-02   1.000 6.92741e-05 1.75147e-02
+        242    21 -228.363541 -228.291166 7.237460e-02   1.000 5.62044e-05 1.75143e-02
+        243    22 -228.363844 -228.291163 7.268104e-02   1.000 4.79220e-05 1.75140e-02
+        244    23 -228.364148 -228.291174 7.297367e-02   1.000 4.92715e-05 1.75137e-02
+        245    22 -228.364453 -228.291194 7.325852e-02   1.000 5.22485e-05 1.75134e-02
+        246    22 -228.364760 -228.291216 7.354366e-02   1.000 5.09078e-05 1.75131e-02
+        247    23 -228.365068 -228.291233 7.383490e-02   1.000 4.67536e-05 1.75128e-02
+        248    23 -228.365377 -228.291242 7.413518e-02   1.000 4.44677e-05 1.75125e-02
+        249    23 -228.365685 -228.291242 7.444387e-02   1.000 4.55133e-05 1.75123e-02
+        250    23 -228.365993 -228.291235 7.475765e-02   1.000 4.71295e-05 1.75120e-02
+        251    23 -228.366300 -228.291227 7.507278e-02   1.000 4.66797e-05 1.75117e-02
+        252    22 -228.366606 -228.291221 7.538456e-02   1.000 4.44412e-05 1.75115e-02
+        253    24 -228.366911 -228.291219 7.569224e-02   1.000 4.19668e-05 1.75113e-02
+        254    23 -228.367217 -228.291222 7.599461e-02   1.000 4.07938e-05 1.75110e-02
+        255    23 -228.367523 -228.291229 7.629396e-02   1.000 4.04281e-05 1.75108e-02
+        256    23 -228.367514 -228.291237 7.627711e-02   1.000 2.40075e-03 1.69727e-02
+        257    18 -228.367522 -228.296447 7.107514e-02   1.000 4.53483e-03 1.66639e-02
+        258    19 -228.367945 -228.304565 6.338011e-02   1.000 3.49453e-03 1.66041e-02
+        259    20 -228.368536 -228.308434 6.010169e-02   1.000 1.13623e-03 1.66372e-02
+        260    22 -228.369067 -228.307310 6.175727e-02   1.000 1.35334e-03 1.66190e-02
+        261    16 -228.369407 -228.303773 6.563379e-02   1.000 1.82254e-03 1.65812e-02
+        262    19 -228.369590 -228.300722 6.886811e-02   1.000 1.20816e-03 1.65670e-02
+        263    20 -228.369743 -228.299704 7.003882e-02   1.000 5.72135e-04 1.65611e-02
+        264    22 -228.369934 -228.300478 6.945601e-02   1.000 7.62523e-04 1.65543e-02
+        265    24 -228.370201 -228.301886 6.831561e-02   1.000 7.11724e-04 1.65508e-02
+        266    17 -228.370516 -228.302884 6.763151e-02   1.000 3.81247e-04 1.65473e-02
+        267    21 -228.370834 -228.303088 6.774666e-02   1.000 2.94786e-04 1.65410e-02
+        268    24 -228.371129 -228.302743 6.838506e-02   1.000 3.67891e-04 1.65358e-02
+        269    19 -228.371396 -228.302309 6.908764e-02   1.000 2.62074e-04 1.65335e-02
+        270    22 -228.371652 -228.302106 6.954612e-02   1.000 9.67585e-05 1.65317e-02
+        271    23 -228.371913 -228.302171 6.974124e-02   1.000 1.51628e-04 1.65285e-02
+        272    23 -228.372183 -228.302357 6.982637e-02   1.000 1.96362e-04 1.65250e-02
+        273    23 -228.372463 -228.302491 6.997220e-02   1.000 1.58929e-04 1.65224e-02
+        274    22 -228.372744 -228.302501 7.024253e-02   1.000 9.81841e-05 1.65202e-02
+        275    24 -228.373019 -228.302428 7.059138e-02   1.000 7.60765e-05 1.65180e-02
+        276    23 -228.373290 -228.302356 7.093470e-02   1.000 8.74952e-05 1.65155e-02
+        277    23 -228.373558 -228.302346 7.121175e-02   1.000 9.95143e-05 1.65131e-02
+        278    24 -228.373827 -228.302403 7.142413e-02   1.000 1.00233e-04 1.65108e-02
+        279    24 -228.374099 -228.302487 7.161262e-02   1.000 8.70615e-05 1.65087e-02
+        280    20 -228.374374 -228.302549 7.182483e-02   1.000 7.14579e-05 1.65065e-02
+        281    23 -228.374600 -228.302567 7.203352e-02   1.000 3.81384e-04 1.63453e-02
+        282    21 -228.374508 -228.303365 7.114333e-02   1.000 3.12116e-03 1.57567e-02
+        283    19 -228.374746 -228.309969 6.477690e-02   1.000 3.32092e-03 1.56685e-02
+        284    20 -228.375170 -228.314575 6.059490e-02   1.000 1.92386e-03 1.56657e-02
+        285    20 -228.375643 -228.315828 5.981545e-02   1.000 5.30233e-04 1.56798e-02
+        286    24 -228.376020 -228.314186 6.183420e-02   1.000 1.22685e-03 1.56655e-02
+        287    16 -228.376286 -228.311510 6.477568e-02   1.000 1.37246e-03 1.56488e-02
+        288    19 -228.376458 -228.309490 6.696753e-02   1.000 8.95291e-04 1.56424e-02
+        289    21 -228.376617 -228.308871 6.774607e-02   1.000 4.54280e-04 1.56400e-02
+        290    22 -228.376801 -228.309403 6.739725e-02   1.000 5.04571e-04 1.56390e-02
+        291    22 -228.377035 -228.310362 6.667278e-02   1.000 4.87600e-04 1.56386e-02
+        292    19 -228.377148 -228.311107 6.604123e-02   1.000 1.45612e-03 1.51308e-02
+        293    19 -228.377060 -228.313860 6.320018e-02   1.000 3.89288e-03 1.46038e-02
+        294    19 -228.377239 -228.321261 5.597788e-02   1.000 4.19964e-03 1.44806e-02
+        295    19 -228.377627 -228.327270 5.035748e-02   1.000 2.77537e-03 1.44860e-02
+        296    20 -228.378090 -228.329707 4.838332e-02   1.000 8.51870e-04 1.45205e-02
+        297    22 -228.378496 -228.328659 4.983657e-02   1.000 1.09799e-03 1.45061e-02
+        298    22 -228.378701 -228.325675 5.302584e-02   1.000 1.15594e-03 1.40546e-02
+        299    21 -228.378373 -228.323872 5.450072e-02   1.000 3.03900e-03 1.28115e-02
+        300    22 -228.378364 -228.331074 4.729066e-02   1.000 4.68441e-03 1.25992e-02
+        301    16 -228.378568 -228.338796 3.977180e-02   1.000 4.30654e-03 1.25003e-02
+        302    19 -228.378936 -228.344270 3.466637e-02   1.000 2.60045e-03 1.25217e-02
+        303    19 -228.379307 -228.346173 3.313344e-02   1.000 8.55674e-04 1.25443e-02
+        304    22 -228.379631 -228.344972 3.465946e-02   1.000 1.16716e-03 1.25337e-02
+        305    16 -228.379861 -228.342128 3.773357e-02   1.000 1.70246e-03 1.25052e-02
+        306    20 -228.379993 -228.339111 4.088181e-02   1.000 1.61057e-03 1.24774e-02
+        307    22 -228.380087 -228.336931 4.315520e-02   1.000 1.16344e-03 1.24626e-02
+        308    22 -228.380161 -228.335928 4.423301e-02   1.000 6.73789e-04 1.24643e-02
+        309    21 -228.380257 -228.335943 4.431400e-02   1.000 4.33600e-04 1.24719e-02
+        310    21 -228.380377 -228.336603 4.377344e-02   1.000 5.62820e-04 1.24712e-02
+        311    22 -228.380520 -228.337539 4.298071e-02   1.000 7.25718e-04 1.24603e-02
+        312    22 -228.380680 -228.338476 4.220370e-02   1.000 7.57365e-04 1.24497e-02
+        313    22 -228.380847 -228.339251 4.159632e-02   1.000 6.44002e-04 1.24470e-02
+        314    19 -228.381023 -228.339769 4.125427e-02   1.000 4.24034e-04 1.24497e-02
+        315    22 -228.381200 -228.339975 4.122504e-02   1.000 1.99278e-04 1.24506e-02
+        316    20 -228.381378 -228.339860 4.151782e-02   1.000 2.03031e-04 1.24473e-02
+        317    24 -228.381549 -228.339472 4.207715e-02   1.000 3.26140e-04 1.24425e-02
+        318    24 -228.381710 -228.338930 4.277929e-02   1.000 3.61474e-04 1.24396e-02
+        319    22 -228.381858 -228.338397 4.346043e-02   1.000 2.90095e-04 1.24391e-02
+        320    21 -228.381997 -228.338030 4.396761e-02   1.000 1.59508e-04 1.24392e-02
+        321    18 -228.382132 -228.337926 4.420582e-02   1.000 1.48004e-04 1.24382e-02
+        322    23 -228.382270 -228.338095 4.417448e-02   1.000 2.74718e-04 1.24362e-02
+        323    21 -228.382416 -228.338457 4.395894e-02   1.000 3.54213e-04 1.24341e-02
+        324    22 -228.382571 -228.338875 4.369588e-02   1.000 3.50261e-04 1.24329e-02
+        325    22 -228.382734 -228.339214 4.352015e-02   1.000 2.75295e-04 1.24321e-02
+        326    19 -228.382903 -228.339383 4.351989e-02   1.000 1.73921e-04 1.24313e-02
+        327    19 -228.383069 -228.339360 4.370872e-02   1.000 1.18731e-04 1.24301e-02
+        328    21 -228.383232 -228.339188 4.404389e-02   1.000 1.33662e-04 1.24287e-02
+        329    20 -228.383387 -228.338950 4.443704e-02   1.000 1.42714e-04 1.24275e-02
+        330    21 -228.383538 -228.338736 4.480209e-02   1.000 1.24050e-04 1.24265e-02
+        331    20 -228.383685 -228.338610 4.507488e-02   1.000 1.10149e-04 1.24257e-02
+        332    20 -228.383832 -228.338598 4.523451e-02   1.000 1.34592e-04 1.24247e-02
+        333    22 -228.383981 -228.338683 4.529756e-02   1.000 1.71343e-04 1.24237e-02
+        334    21 -228.384133 -228.338825 4.530786e-02   1.000 1.90228e-04 1.24226e-02
+        335    20 -228.384289 -228.338973 4.531555e-02   1.000 1.83803e-04 1.24216e-02
+        336    22 -228.384447 -228.339085 4.536114e-02   1.000 1.59302e-04 1.24206e-02
+        337    18 -228.384605 -228.339140 4.546500e-02   1.000 1.30687e-04 1.24197e-02
+        338    18 -228.384763 -228.339135 4.562820e-02   1.000 1.10842e-04 1.24187e-02
+        339    20 -228.384919 -228.339087 4.583190e-02   1.000 1.02873e-04 1.24176e-02
+        340    20 -228.385074 -228.339023 4.605108e-02   1.000 1.00984e-04 1.24166e-02
+        341    20 -228.385227 -228.338966 4.626076e-02   1.000 1.01680e-04 1.24156e-02
+        342    21 -228.385379 -228.338935 4.644430e-02   1.000 1.06291e-04 1.24146e-02
+        343    20 -228.385531 -228.338936 4.659488e-02   1.000 1.14917e-04 1.24136e-02
+        344    19 -228.385684 -228.338966 4.671763e-02   1.000 1.23717e-04 1.24126e-02
+        345    22 -228.385837 -228.339015 4.682221e-02   1.000 1.28546e-04 1.24115e-02
+        346    19 -228.385991 -228.339067 4.692403e-02   1.000 1.27262e-04 1.24105e-02
+        347    21 -228.386146 -228.339112 4.703399e-02   1.000 1.21250e-04 1.24094e-02
+        348    19 -228.386301 -228.339141 4.716088e-02   1.000 1.13057e-04 1.24083e-02
+        349    21 -228.386457 -228.339152 4.730492e-02   1.000 1.05813e-04 1.24072e-02
+        350    20 -228.386611 -228.339148 4.746254e-02   1.000 1.01060e-04 1.24060e-02
+        351    20 -228.386766 -228.339138 4.762777e-02   1.000 9.86790e-05 1.24048e-02
+        352    21 -228.386919 -228.339128 4.779089e-02   1.000 9.87001e-05 1.24035e-02
+        353    20 -228.387072 -228.339126 4.794671e-02   1.000 1.00463e-04 1.24022e-02
+        354    21 -228.387226 -228.339133 4.809212e-02   1.000 1.03333e-04 1.24009e-02
+        355    21 -228.387379 -228.339152 4.822710e-02   1.000 1.06128e-04 1.23995e-02
+        356    21 -228.387532 -228.339177 4.835511e-02   1.000 1.07881e-04 1.23980e-02
+        357    20 -228.387685 -228.339206 4.847917e-02   1.000 1.08283e-04 1.23964e-02
+        358    20 -228.387840 -228.339234 4.860571e-02   1.000 1.07135e-04 1.23946e-02
+        359    22 -228.387993 -228.339259 4.873491e-02   1.000 1.05835e-04 1.23928e-02
+        360    21 -228.388147 -228.339278 4.886910e-02   1.000 1.05108e-04 1.23907e-02
+        361    22 -228.388301 -228.339295 4.900592e-02   1.000 1.06340e-04 1.23884e-02
+        362    21 -228.388454 -228.339312 4.914268e-02   1.000 1.10756e-04 1.23857e-02
+        363    22 -228.388607 -228.339333 4.927463e-02   1.000 1.21974e-04 1.23823e-02
+        364    22 -228.388248 -228.339364 4.888451e-02   1.000 3.94827e-03 1.04818e-02
+        365    20 -228.387929 -228.347951 3.997728e-02   1.000 7.45254e-03 9.53983e-03
+        366    20 -228.387986 -228.361084 2.690203e-02   1.000 7.88723e-03 9.14409e-03
+        367    18 -228.388343 -228.371948 1.639533e-02   1.000 5.64838e-03 9.30045e-03
+        368    17 -228.388834 -228.377481 1.135280e-02   1.000 2.02910e-03 9.55098e-03
+        369    18 -228.389312 -228.377025 1.228728e-02   1.000 1.59567e-03 9.50271e-03
+        370    24 -228.389649 -228.372011 1.763820e-02   1.000 3.77570e-03 9.25978e-03
+        371    19 -228.389777 -228.365034 2.474215e-02   1.000 4.24928e-03 9.11402e-03
+        372    18 -228.389753 -228.358819 3.093337e-02   1.000 3.21533e-03 9.14913e-03
+        373    18 -228.389618 -228.355252 3.436643e-02   1.000 1.38257e-03 9.22618e-03
+        374    18 -228.389486 -228.354916 3.456952e-02   1.000 6.29216e-04 9.22239e-03
+        375    25 -228.389413 -228.357215 3.219862e-02   1.000 1.90042e-03 9.15575e-03
+        376    21 -228.389452 -228.360821 2.863035e-02   1.000 2.32777e-03 9.10829e-03
+        377    18 -228.389583 -228.364275 2.530802e-02   1.000 1.91283e-03 9.11174e-03
+        378    18 -228.389770 -228.366483 2.328729e-02   1.000 1.01847e-03 9.13226e-03
+        379    18 -228.389970 -228.367013 2.295684e-02   1.000 2.34215e-04 9.13320e-03
+        380    28 -228.390141 -228.366078 2.406306e-02   1.000 8.23503e-04 9.11534e-03
+        381    20 -228.390258 -228.364308 2.595018e-02   1.000 1.13285e-03 9.10040e-03
+        382    19 -228.390328 -228.362468 2.785923e-02   1.000 1.00019e-03 9.09896e-03
+        383    17 -228.390357 -228.361169 2.918757e-02   1.000 5.83644e-04 9.10344e-03
+        384    18 -228.390383 -228.360707 2.967598e-02   1.000 1.66873e-04 9.10367e-03
+        385    27 -228.390414 -228.361034 2.938032e-02   1.000 4.16254e-04 9.09866e-03
+        386    21 -228.390475 -228.361866 2.860943e-02   1.000 6.15162e-04 9.09359e-03
+        387    20 -228.390559 -228.362818 2.774120e-02   1.000 5.95990e-04 9.09136e-03
+        388    19 -228.390664 -228.363561 2.710286e-02   1.000 4.19271e-04 9.09016e-03
+        389    19 -228.390775 -228.363909 2.686599e-02   1.000 2.04261e-04 9.08675e-03
+        390    22 -228.390476 -228.363853 2.662332e-02   1.000 3.03484e-03 5.51291e-03
+        391    19 -228.390072 -228.370300 1.977136e-02   1.000 6.58440e-03 3.41240e-03
+        392    24 -228.389898 -228.382352 7.545935e-03   1.000 8.07084e-03 1.53981e-03
+        393    27 -228.389978 -228.394566 4.587631e-03   1.000 7.36134e-03 1.07115e-03
+        394    28 -228.390256 -228.403915 1.365908e-02   1.000 4.90993e-03 2.40002e-03
+        395    18 -228.390636 -228.408530 1.789410e-02   1.000 1.64579e-03 3.06096e-03
+        396    19 -228.390988 -228.407970 1.698220e-02   1.000 1.55667e-03 2.88063e-03
+        397    24 -228.391259 -228.403180 1.192090e-02   1.000 3.80276e-03 2.06456e-03
+        398    24 -228.391373 -228.395982 4.609464e-03   1.000 4.76678e-03 1.02622e-03
+        399    26 -228.391343 -228.388536 2.807119e-03   1.000 4.40770e-03 8.27348e-04
+        400    26 -228.391179 -228.382701 8.478014e-03   1.000 3.01010e-03 1.48478e-03
+        401    20 -228.390953 -228.379672 1.128154e-02   1.000 1.08387e-03 1.84855e-03
+        402    20 -228.390734 -228.379792 1.094165e-02   1.000 8.96200e-04 1.76532e-03
+        403    24 -228.390566 -228.382558 8.008522e-03   1.000 2.30104e-03 1.33391e-03
+        404    24 -228.390488 -228.386882 3.606492e-03   1.000 2.94687e-03 8.05631e-04
+        405    27 -228.390503 -228.391448 9.452925e-04   1.000 2.78043e-03 6.71332e-04
+        406    24 -228.390599 -228.395100 4.500678e-03   1.000 1.96603e-03 9.66830e-04
+        407    20 -228.390735 -228.397069 6.333984e-03   1.000 8.07713e-04 1.17181e-03
+        408    18 -228.390873 -228.397116 6.242664e-03   1.000 4.23440e-04 1.14391e-03
+        409    23 -228.390979 -228.395518 4.539462e-03   1.000 1.29102e-03 9.24665e-04
+        410    21 -228.391029 -228.392925 1.895557e-03   1.000 1.71464e-03 6.60168e-04
+        411    24 -228.391023 -228.390139 8.839776e-04   1.000 1.64148e-03 5.78302e-04
+        412    21 -228.390965 -228.387879 3.086675e-03   1.000 1.16226e-03 7.02286e-04
+        413    18 -228.390885 -228.386635 4.250009e-03   1.000 4.63615e-04 8.11323e-04
+        414    19 -228.390801 -228.386566 4.234953e-03   1.000 2.82606e-04 8.05757e-04
+        415    24 -228.390737 -228.387509 3.228401e-03   1.000 8.25112e-04 7.00525e-04
+        416    19 -228.390707 -228.389078 1.628737e-03   1.000 1.09532e-03 5.76740e-04
+        417    22 -228.390709 -228.390783 7.402579e-05   1.000 1.06443e-03 5.34641e-04
+        418    23 -228.390744 -228.392178 1.434390e-03   1.000 7.79940e-04 5.81249e-04
+        419    16 -228.390793 -228.392965 2.172171e-03   1.000 3.58199e-04 6.30795e-04
+        420    16 -228.390845 -228.393039 2.194186e-03   1.000 1.10183e-04 6.29715e-04
+        421    24 -228.390884 -228.392493 1.608910e-03   1.000 4.34883e-04 5.81886e-04
+        422    19 -228.390903 -228.391557 6.541410e-04   1.000 6.05813e-04 5.27134e-04
+        423    18 -228.390902 -228.390528 3.739201e-04   1.000 5.93090e-04 5.06720e-04
+        424    18 -228.390883 -228.389682 1.201062e-03   1.000 4.26802e-04 5.22374e-04
+        425    15 -228.390854 -228.389199 1.654437e-03   1.000 1.75237e-04 5.41993e-04
+        426    17 -228.390824 -228.389148 1.675121e-03   1.000 1.08767e-04 5.41346e-04
+        427    23 -228.390800 -228.389474 1.325706e-03   1.000 3.10318e-04 5.20787e-04
+        428    18 -228.390789 -228.390040 7.485168e-04   1.000 4.16049e-04 4.97354e-04
+        429    16 -228.390790 -228.390666 1.233693e-04   1.000 4.11317e-04 4.87178e-04
+        430    16 -228.390801 -228.391187 3.859589e-04   1.000 3.12251e-04 4.90987e-04
+        431    15 -228.390819 -228.391490 6.712786e-04   1.000 1.61433e-04 4.97071e-04
+        432    16 -228.390838 -228.391534 6.964365e-04   1.000 4.41006e-05 4.95579e-04
+        433    22 -228.390852 -228.391349 4.965046e-04   1.000 1.40936e-04 4.86148e-04
+        434    19 -228.390860 -228.391017 1.571497e-04   1.000 2.05678e-04 4.75495e-04
+        435    18 -228.390860 -228.390645 2.145780e-04   1.000 2.05083e-04 4.69876e-04
+        436    18 -228.390854 -228.390335 5.189299e-04   1.000 1.48733e-04 4.69706e-04
+        437    18 -228.390844 -228.390153 6.906247e-04   1.000 6.52590e-05 4.70698e-04
+        438    17 -228.390833 -228.390126 7.064348e-04   1.000 5.90784e-05 4.68957e-04
+        439    21 -228.390824 -228.390238 5.862390e-04   1.000 1.27507e-04 4.64151e-04
+        440    17 -228.390820 -228.390440 3.802596e-04   1.000 1.66978e-04 4.58766e-04
+        441    18 -228.390820 -228.390667 1.533764e-04   1.000 1.67052e-04 4.55203e-04
+        442    16 -228.390824 -228.390860 3.563459e-05   1.000 1.33707e-04 4.53712e-04
+        443    17 -228.390831 -228.390976 1.456173e-04   1.000 8.19847e-05 4.52752e-04
+        444    17 -228.390838 -228.391000 1.620151e-04   1.000 3.86394e-05 4.50829e-04
+        445    19 -228.390843 -228.390939 9.597141e-05   1.000 4.79041e-05 4.47767e-04
+        446    19 -228.390846 -228.390824 2.226522e-05   1.000 6.78956e-05 4.44486e-04
+        447    18 -228.390847 -228.390692 1.547862e-04   1.000 6.89633e-05 4.41901e-04
+        448    18 -228.390845 -228.390579 2.655592e-04   1.000 5.26812e-05 4.40134e-04
+        449    18 -228.390841 -228.390511 3.298549e-04   1.000 3.43178e-05 4.38623e-04
+        450    18 -228.390838 -228.390499 3.383483e-04   1.000 4.19801e-05 4.36790e-04
+        451    18 -228.390835 -228.390537 2.971367e-04   1.000 6.31934e-05 4.34541e-04
+        452    18 -228.390833 -228.390609 2.239187e-04   1.000 7.66460e-05 4.32204e-04
+        453    18 -228.390833 -228.390692 1.414112e-04   1.000 7.72282e-05 4.30125e-04
+        454    16 -228.390835 -228.390764 7.098907e-05   1.000 6.64193e-05 4.28362e-04
+        455    17 -228.390837 -228.390809 2.814042e-05   1.000 4.96714e-05 4.26718e-04
+        456    17 -228.390840 -228.390821 1.899533e-05   1.000 3.50140e-05 4.24975e-04
+        457    18 -228.390842 -228.390802 3.991669e-05   1.000 2.96590e-05 4.23097e-04
+        458    19 -228.390843 -228.390763 8.031898e-05   1.000 3.07355e-05 4.21201e-04
+        459    19 -228.390843 -228.390717 1.268196e-04   1.000 3.07890e-05 4.19419e-04
+        460    19 -228.390843 -228.390677 1.664227e-04   1.000 2.88119e-05 4.17773e-04
+        461    19 -228.390842 -228.390652 1.899355e-04   1.000 2.88374e-05 4.16191e-04
+        462    18 -228.390841 -228.390647 1.936569e-04   1.000 3.34625e-05 4.14590e-04
+        463    18 -228.390840 -228.390660 1.793378e-04   1.000 3.97546e-05 4.12952e-04
+        464    16 -228.390839 -228.390686 1.528027e-04   1.000 4.38019e-05 4.11316e-04
+        465    17 -228.390839 -228.390717 1.223461e-04   1.000 4.39533e-05 4.09730e-04
+        466    17 -228.390840 -228.390744 9.580576e-05   1.000 4.04995e-05 4.08206e-04
+        467    17 -228.390841 -228.390762 7.894254e-05   1.000 3.51823e-05 4.06717e-04
+        468    17 -228.390842 -228.390768 7.412484e-05   1.000 3.01334e-05 4.05235e-04
+        469    18 -228.390843 -228.390763 8.020054e-05   1.000 2.68760e-05 4.03752e-04
+        470    19 -228.390843 -228.390750 9.349076e-05   1.000 2.53739e-05 4.02281e-04
+        471    19 -228.390844 -228.390734 1.093067e-04   1.000 2.48712e-05 4.00842e-04
+        472    19 -228.390844 -228.390721 1.230162e-04   1.000 2.50201e-05 3.99437e-04
+        473    19 -228.390843 -228.390712 1.312035e-04   1.000 2.59951e-05 3.98057e-04
+        474    18 -228.390843 -228.390711 1.324271e-04   1.000 2.77106e-05 3.96691e-04
+        475    18 -228.390843 -228.390716 1.271081e-04   1.000 2.95069e-05 3.95334e-04
+        476    18 -228.390843 -228.390725 1.172597e-04   1.000 3.05693e-05 3.93990e-04
+        477    18 -228.390843 -228.390737 1.057570e-04   1.000 3.04576e-05 3.92667e-04
+        478    16 -228.390843 -228.390748 9.543632e-05   1.000 2.92300e-05 3.91365e-04
+        479    17 -228.390844 -228.390755 8.847009e-05   1.000 2.73830e-05 3.90081e-04
+        480    17 -228.390844 -228.390758 8.576554e-05   1.000 2.54704e-05 3.88811e-04
+        481    17 -228.390845 -228.390757 8.706680e-05   1.000 2.39595e-05 3.87554e-04
+        482    18 -228.390845 -228.390754 9.104828e-05   1.000 2.29909e-05 3.86310e-04
+        483    19 -228.390845 -228.390749 9.605740e-05   1.000 2.25149e-05 3.85083e-04
+        484    18 -228.390845 -228.390745 1.005184e-04   1.000 2.24610e-05 3.83871e-04
+        485    19 -228.390845 -228.390742 1.031063e-04   1.000 2.27353e-05 3.82675e-04
+        486    16 -228.390845 -228.390742 1.032992e-04   1.000 2.31732e-05 3.81492e-04
+        487    16 -228.390845 -228.390744 1.011267e-04   1.000 2.36069e-05 3.80320e-04
+        488    17 -228.390845 -228.390748 9.718344e-05   1.000 2.37595e-05 3.79161e-04
+        489    17 -228.390845 -228.390753 9.256063e-05   1.000 2.35620e-05 3.78015e-04
+        490    17 -228.390846 -228.390757 8.828527e-05   1.000 2.29957e-05 3.76881e-04
+        491    17 -228.390846 -228.390761 8.516989e-05   1.000 2.22190e-05 3.75760e-04
+        492    17 -228.390846 -228.390763 8.358769e-05   1.000 2.13835e-05 3.74651e-04
+        493    17 -228.390846 -228.390763 8.347613e-05   1.000 2.06489e-05 3.73552e-04
+        494    17 -228.390847 -228.390762 8.441202e-05   1.000 2.00873e-05 3.72465e-04
+        495    18 -228.390847 -228.390761 8.573810e-05   1.000 1.97299e-05 3.71388e-04
+        496    16 -228.390847 -228.390760 8.695141e-05   1.000 1.95245e-05 3.70323e-04
+        497    18 -228.390847 -228.390760 8.752433e-05   1.000 1.94810e-05 3.69268e-04
+        498    18 -228.390847 -228.390760 8.718165e-05   1.000 1.94655e-05 3.68224e-04
+        499    18 -228.390847 -228.390761 8.606667e-05   1.000 1.94410e-05 3.67189e-04
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization converged in  14 iterations 
+            Total energy change: -8.575586e-04
+            Final gradient norm: 9.613244e-07
+
+        500    19 -228.391705 -228.382952 8.753316e-03   0.053 1.93350e-05 3.66164e-04
+        501    23 -228.390203 -228.391621 1.417931e-03   0.053 7.61144e-03 4.23418e-04
+        502    16 -228.390774 -228.391626 8.527683e-04   0.053 3.89954e-03 3.54073e-04
+        503    19 -228.391462 -228.391637 1.750540e-04   0.053 1.45439e-03 3.44763e-04
+        504    18 -228.391767 -228.391649 1.186877e-04   0.053 1.54376e-03 3.18421e-04
+        505    18 -228.391750 -228.391660 8.984855e-05   0.053 5.59135e-04 3.12264e-04
+        506    15 -228.391748 -228.391670 7.742732e-05   0.053 4.37608e-04 2.98388e-04
+        507    17 -228.391826 -228.391678 1.485769e-04   0.053 6.75223e-04 2.81942e-04
+        508    17 -228.391895 -228.391682 2.129876e-04   0.053 7.56995e-04 2.71657e-04
+        509    17 -228.391886 -228.391682 2.038208e-04   0.053 6.10762e-04 2.65722e-04
+        510    15 -228.391778 -228.391681 9.728858e-05   0.053 2.57384e-04 2.60780e-04
+        511    12 -228.391705 -228.391676 2.956973e-05   0.053 1.75883e-04 2.54604e-04
+        512    16 -228.391635 -228.391673 3.796072e-05   0.053 3.67212e-04 2.47834e-04
+        513    15 -228.391639 -228.391669 3.013029e-05   0.053 4.00404e-04 2.42170e-04
+        514    16 -228.391657 -228.391668 1.134263e-05   0.053 2.95925e-04 2.38023e-04
+        515    15 -228.391701 -228.391668 3.343097e-05   0.053 1.50338e-04 2.34597e-04
+        516    15 -228.391732 -228.391669 6.211674e-05   0.053 7.74361e-05 2.31175e-04
+        517    15 -228.391763 -228.391672 9.097626e-05   0.053 1.44409e-04 2.27767e-04
+        518    15 -228.391766 -228.391674 9.201902e-05   0.053 1.73993e-04 2.24739e-04
+        519    14 -228.391748 -228.391677 7.109580e-05   0.053 1.49560e-04 2.22253e-04
+        520    13 -228.391762 -228.391677 8.549338e-05   0.053 8.55128e-05 2.20160e-04
+        521    15 -228.391730 -228.391678 5.195616e-05   0.053 3.54905e-05 2.18249e-04
+        522    15 -228.391728 -228.391677 5.145694e-05   0.053 6.38192e-05 2.16459e-04
+        523    16 -228.391717 -228.391676 4.115332e-05   0.053 8.45102e-05 2.14844e-04
+        524    15 -228.391722 -228.391674 4.830009e-05   0.053 8.16061e-05 2.13444e-04
+        525    15 -228.391725 -228.391673 5.211350e-05   0.053 5.82530e-05 2.12233e-04
+        526    15 -228.391737 -228.391673 6.471516e-05   0.053 3.45521e-05 2.11153e-04
+        527    15 -228.391742 -228.391673 6.965271e-05   0.053 3.10900e-05 2.10176e-04
+        528    16 -228.391748 -228.391673 7.485766e-05   0.053 3.90344e-05 2.09299e-04
+        529    15 -228.391748 -228.391674 7.428834e-05   0.053 3.90169e-05 2.08528e-04
+        530    14 -228.391747 -228.391674 7.266338e-05   0.053 3.08556e-05 2.07852e-04
+        531    14 -228.391744 -228.391675 6.919541e-05   0.053 2.12019e-05 2.07256e-04
+        532    15 -228.391743 -228.391675 6.753893e-05   0.053 1.92453e-05 2.06724e-04
+        533    15 -228.391741 -228.391676 6.515495e-05   0.053 2.26792e-05 2.06249e-04
+        534    15 -228.391742 -228.391675 6.691471e-05   0.053 2.46105e-05 2.05829e-04
+        535    15 -228.391743 -228.391675 6.810578e-05   0.053 2.34029e-05 2.05457e-04
+        536    15 -228.391746 -228.391674 7.163352e-05   0.053 2.01426e-05 2.05129e-04
+        537    15 -228.391748 -228.391674 7.375394e-05   0.053 1.80007e-05 2.04837e-04
+        538    15 -228.391750 -228.391674 7.625628e-05   0.053 1.69884e-05 2.04578e-04
+        539    15 -228.391751 -228.391674 7.698142e-05   0.053 1.67322e-05 2.04349e-04
+        540    15 -228.391752 -228.391674 7.771524e-05   0.053 1.60046e-05 2.04145e-04
+        541    15 -228.391751 -228.391674 7.728109e-05   0.053 1.53515e-05 2.03966e-04
+        542    15 -228.391752 -228.391674 7.764688e-05   0.053 1.48199e-05 2.03807e-04
+        543    15 -228.391752 -228.391675 7.703405e-05   0.053 1.49695e-05 2.03665e-04
+        544    15 -228.391753 -228.391675 7.801265e-05   0.053 1.48796e-05 2.03540e-04
+        545    15 -228.391753 -228.391675 7.838484e-05   0.053 1.51410e-05 2.03429e-04
+        546    14 -228.391755 -228.391675 7.987016e-05   0.053 1.43190e-05 2.03331e-04
+        547    15 -228.391755 -228.391675 8.047145e-05   0.053 1.48589e-05 2.03243e-04
+        548    15 -228.391757 -228.391674 8.283108e-05   0.053 1.41501e-05 2.03166e-04
+        549    15 -228.391757 -228.391674 8.299061e-05   0.053 1.44430e-05 2.03097e-04
+        550    15 -228.391759 -228.391674 8.472962e-05   0.053 1.39531e-05 2.03036e-04
+        551    16 -228.391759 -228.391674 8.480559e-05   0.053 1.39139e-05 2.02982e-04
+        552    13 -228.391760 -228.391674 8.575994e-05   0.053 1.34062e-05 2.02934e-04
+        553    15 -228.391760 -228.391674 8.586011e-05   0.053 1.39314e-05 2.02892e-04
+        554    15 -228.391761 -228.391674 8.730284e-05   0.053 1.37719e-05 2.02854e-04
+        555    15 -228.391761 -228.391674 8.694253e-05   0.053 1.40369e-05 2.02820e-04
+        556    11 -228.391763 -228.391674 8.826579e-05   0.053 1.33362e-05 2.02790e-04
+        557    15 -228.391763 -228.391674 8.876380e-05   0.053 1.33870e-05 2.02763e-04
+        558    15 -228.391765 -228.391674 9.018186e-05   0.053 1.36801e-05 2.02740e-04
+        559    11 -228.391765 -228.391674 9.099610e-05   0.053 1.32933e-05 2.02719e-04
+        560    15 -228.391766 -228.391674 9.195635e-05   0.053 1.32221e-05 2.02700e-04
+        561    15 -228.391766 -228.391674 9.229002e-05   0.053 1.34604e-05 2.02683e-04
+        562    12 -228.391768 -228.391674 9.438560e-05   0.053 1.31457e-05 2.02668e-04
+        563    15 -228.391768 -228.391674 9.341586e-05   0.053 1.30562e-05 2.02655e-04
+        564    12 -228.391770 -228.391674 9.566816e-05   0.053 1.31171e-05 2.02643e-04
+        565    15 -228.391769 -228.391674 9.489446e-05   0.053 1.30711e-05 2.02632e-04
+        566    15 -228.391771 -228.391674 9.680670e-05   0.053 1.32382e-05 2.02622e-04
+        567    11 -228.391771 -228.391674 9.682557e-05   0.053 1.29897e-05 2.02613e-04
+        568    15 -228.391772 -228.391674 9.825750e-05   0.053 1.28174e-05 2.02606e-04
+        569    15 -228.391772 -228.391674 9.817870e-05   0.053 1.31654e-05 2.02599e-04
+        570    11 -228.391774 -228.391674 9.936716e-05   0.053 1.29377e-05 2.02592e-04
+        571    15 -228.391775 -228.391674 1.007302e-04   0.053 1.28042e-05 2.02587e-04
+        572    12 -228.391775 -228.391674 1.006192e-04   0.053 1.29918e-05 2.02581e-04
+        573    15 -228.391776 -228.391674 1.022028e-04   0.053 1.28734e-05 2.02577e-04
+        574    12 -228.391776 -228.391674 1.015754e-04   0.053 1.29635e-05 2.02572e-04
+        575    15 -228.391778 -228.391674 1.040870e-04   0.053 1.27959e-05 2.02568e-04
+        576    12 -228.391778 -228.391674 1.035084e-04   0.053 1.29722e-05 2.02565e-04
+        577    14 -228.391779 -228.391674 1.053139e-04   0.053 1.27753e-05 2.02562e-04
+        578    12 -228.391779 -228.391674 1.052351e-04   0.053 1.28982e-05 2.02558e-04
+        579    15 -228.391781 -228.391674 1.068328e-04   0.053 1.27167e-05 2.02556e-04
+        580    12 -228.391781 -228.391674 1.064536e-04   0.053 1.29187e-05 2.02553e-04
+        581    15 -228.391783 -228.391674 1.085885e-04   0.053 1.27029e-05 2.02551e-04
+        582    12 -228.391782 -228.391674 1.083175e-04   0.053 1.28854e-05 2.02548e-04
+        583    12 -228.391785 -228.391674 1.104032e-04   0.053 1.26670e-05 2.02546e-04
+        584    15 -228.391784 -228.391674 1.098308e-04   0.053 1.26194e-05 2.02544e-04
+        585    15 -228.391786 -228.391674 1.115538e-04   0.053 1.29645e-05 2.02542e-04
+        586    11 -228.391786 -228.391674 1.119212e-04   0.053 1.26979e-05 2.02541e-04
+        587    15 -228.391787 -228.391674 1.130230e-04   0.053 1.24582e-05 2.02539e-04
+        588    12 -228.391787 -228.391674 1.125930e-04   0.053 1.27721e-05 2.02537e-04
+        589    15 -228.391789 -228.391674 1.148776e-04   0.053 1.26445e-05 2.02536e-04
+        590    11 -228.391789 -228.391674 1.147155e-04   0.053 1.27085e-05 2.02534e-04
+        591    15 -228.391790 -228.391674 1.161310e-04   0.053 1.25457e-05 2.02533e-04
+        592    11 -228.391791 -228.391674 1.165435e-04   0.053 1.27650e-05 2.02532e-04
+        593    15 -228.391792 -228.391674 1.176157e-04   0.053 1.24826e-05 2.02530e-04
+        594    10 -228.391792 -228.391674 1.180136e-04   0.053 1.27653e-05 2.02529e-04
+        595    15 -228.391793 -228.391674 1.191516e-04   0.053 1.25112e-05 2.02528e-04
+        596    12 -228.391793 -228.391674 1.191482e-04   0.053 1.27697e-05 2.02526e-04
+        597    15 -228.391795 -228.391674 1.208947e-04   0.053 1.24600e-05 2.02525e-04
+        598    10 -228.391795 -228.391674 1.207154e-04   0.053 1.27219e-05 2.02524e-04
+        599    11 -228.391796 -228.391674 1.223406e-04   0.053 1.23196e-05 2.02523e-04
+        600    15 -228.391797 -228.391674 1.225719e-04   0.053 1.25857e-05 2.02522e-04
+        601    12 -228.391798 -228.391674 1.240607e-04   0.053 1.27739e-05 2.02521e-04
+        602    15 -228.391798 -228.391674 1.240670e-04   0.053 1.23671e-05 2.02520e-04
+        603    11 -228.391799 -228.391674 1.253572e-04   0.053 1.24961e-05 2.02519e-04
+        604    15 -228.391800 -228.391674 1.256844e-04   0.053 1.23070e-05 2.02517e-04
+        605    15 -228.391801 -228.391674 1.270194e-04   0.053 1.25248e-05 2.02516e-04
+        606    11 -228.391802 -228.391674 1.277477e-04   0.053 1.24635e-05 2.02515e-04
+        607    15 -228.391802 -228.391674 1.278696e-04   0.053 1.22162e-05 2.02514e-04
+        608    10 -228.391804 -228.391674 1.294448e-04   0.053 1.26177e-05 2.02513e-04
+        609    14 -228.391804 -228.391674 1.295333e-04   0.053 1.22414e-05 2.02512e-04
+        610    12 -228.391806 -228.391674 1.317934e-04   0.053 1.26726e-05 2.02511e-04
+        611    15 -228.391805 -228.391674 1.305777e-04   0.053 1.22480e-05 2.02510e-04
+        612    10 -228.391807 -228.391674 1.326108e-04   0.053 1.25876e-05 2.02509e-04
+        613    14 -228.391807 -228.391674 1.326834e-04   0.053 1.21372e-05 2.02508e-04
+        614    12 -228.391808 -228.391674 1.337785e-04   0.053 1.25508e-05 2.02507e-04
+        615    14 -228.391809 -228.391674 1.347141e-04   0.053 1.22221e-05 2.02506e-04
+        616    15 -228.391809 -228.391674 1.350103e-04   0.053 1.24828e-05 2.02505e-04
+        617    12 -228.391811 -228.391674 1.367643e-04   0.053 1.22954e-05 2.02504e-04
+        618    15 -228.391810 -228.391674 1.363228e-04   0.053 1.21139e-05 2.02503e-04
+        619    10 -228.391812 -228.391674 1.381520e-04   0.053 1.23988e-05 2.02502e-04
+        620    11 -228.391812 -228.391674 1.380315e-04   0.053 1.21042e-05 2.02501e-04
+        621    14 -228.391813 -228.391674 1.392016e-04   0.053 1.22764e-05 2.02501e-04
+        622    12 -228.391814 -228.391674 1.397980e-04   0.053 1.25001e-05 2.02500e-04
+        623    15 -228.391815 -228.391674 1.409689e-04   0.053 1.20875e-05 2.02499e-04
+        624    15 -228.391815 -228.391674 1.412455e-04   0.053 1.23998e-05 2.02498e-04
+        625    11 -228.391817 -228.391674 1.426226e-04   0.053 1.20776e-05 2.02497e-04
+        626    15 -228.391817 -228.391674 1.427307e-04   0.053 1.19977e-05 2.02496e-04
+        627    12 -228.391819 -228.391674 1.446692e-04   0.053 1.23355e-05 2.02495e-04
+        628    13 -228.391818 -228.391674 1.441184e-04   0.053 1.19809e-05 2.02494e-04
+        629    12 -228.391820 -228.391674 1.461316e-04   0.053 1.23548e-05 2.02493e-04
+        630    15 -228.391820 -228.391674 1.455556e-04   0.053 1.21088e-05 2.02492e-04
+        631    12 -228.391822 -228.391674 1.475232e-04   0.053 1.23556e-05 2.02491e-04
+        632    15 -228.391821 -228.391674 1.472089e-04   0.053 1.19892e-05 2.02490e-04
+        633    10 -228.391823 -228.391674 1.490516e-04   0.053 1.23337e-05 2.02489e-04
+        634    12 -228.391823 -228.391674 1.483656e-04   0.053 1.19458e-05 2.02488e-04
+        635    14 -228.391825 -228.391674 1.505135e-04   0.053 1.20429e-05 2.02487e-04
+        636    12 -228.391825 -228.391674 1.504224e-04   0.053 1.22831e-05 2.02486e-04
+        637    15 -228.391826 -228.391674 1.519384e-04   0.053 1.20306e-05 2.02485e-04
+        638    15 -228.391826 -228.391674 1.520836e-04   0.053 1.21631e-05 2.02485e-04
+        639    11 -228.391827 -228.391674 1.533924e-04   0.053 1.19407e-05 2.02484e-04
+        640    15 -228.391828 -228.391674 1.535789e-04   0.053 1.18463e-05 2.02483e-04
+        641    11 -228.391829 -228.391674 1.547414e-04   0.053 1.20850e-05 2.02482e-04
+        642    13 -228.391829 -228.391674 1.552893e-04   0.053 1.18156e-05 2.02481e-04
+        643    15 -228.391831 -228.391674 1.565347e-04   0.053 1.20746e-05 2.02480e-04
+        644    11 -228.391831 -228.391674 1.569233e-04   0.053 1.20805e-05 2.02479e-04
+        645    15 -228.391832 -228.391674 1.580116e-04   0.053 1.18465e-05 2.02478e-04
+        646    12 -228.391832 -228.391674 1.576002e-04   0.053 1.20842e-05 2.02477e-04
+        647    15 -228.391834 -228.391674 1.599558e-04   0.053 1.18592e-05 2.02476e-04
+        648    12 -228.391834 -228.391674 1.595307e-04   0.053 1.20367e-05 2.02475e-04
+        649    12 -228.391836 -228.391674 1.616216e-04   0.053 1.18763e-05 2.02474e-04
+        650    15 -228.391835 -228.391674 1.611690e-04   0.053 1.18405e-05 2.02474e-04
+        651    12 -228.391837 -228.391674 1.629540e-04   0.053 1.21024e-05 2.02473e-04
+        652    12 -228.391837 -228.391674 1.625946e-04   0.053 1.18189e-05 2.02472e-04
+        653    15 -228.391839 -228.391674 1.643867e-04   0.053 1.18036e-05 2.02471e-04
+        654    12 -228.391838 -228.391674 1.642015e-04   0.053 1.20448e-05 2.02470e-04
+        655    15 -228.391840 -228.391674 1.659070e-04   0.053 1.16864e-05 2.02469e-04
+        656    12 -228.391840 -228.391674 1.657700e-04   0.053 1.19235e-05 2.02468e-04
+        657    12 -228.391842 -228.391674 1.678418e-04   0.053 1.17574e-05 2.02467e-04
+        658    15 -228.391842 -228.391674 1.673605e-04   0.053 1.17170e-05 2.02466e-04
+        659    12 -228.391843 -228.391674 1.692737e-04   0.053 1.20147e-05 2.02465e-04
+        660    11 -228.391843 -228.391674 1.690768e-04   0.053 1.17176e-05 2.02465e-04
+        661    15 -228.391845 -228.391674 1.704491e-04   0.053 1.16695e-05 2.02464e-04
+        662    10 -228.391845 -228.391674 1.709369e-04   0.053 1.20106e-05 2.02463e-04
+        663    11 -228.391845 -228.391674 1.710696e-04   0.053 1.15346e-05 2.02462e-04
+        664    15 -228.391847 -228.391674 1.729491e-04   0.053 1.17648e-05 2.02461e-04
+        665    12 -228.391847 -228.391674 1.727604e-04   0.053 1.19767e-05 2.02460e-04
+        666    12 -228.391849 -228.391674 1.749294e-04   0.053 1.17191e-05 2.02459e-04
+        667    15 -228.391848 -228.391674 1.743111e-04   0.053 1.15849e-05 2.02458e-04
+        668    12 -228.391850 -228.391674 1.761762e-04   0.053 1.18801e-05 2.02457e-04
+        669    12 -228.391850 -228.391674 1.757460e-04   0.053 1.16388e-05 2.02457e-04
+        670    15 -228.391852 -228.391674 1.775913e-04   0.053 1.15912e-05 2.02456e-04
+        671    12 -228.391852 -228.391674 1.774088e-04   0.053 1.18554e-05 2.02455e-04
+        672    15 -228.391853 -228.391674 1.791170e-04   0.053 1.15509e-05 2.02454e-04
+        673    12 -228.391853 -228.391674 1.789950e-04   0.053 1.17394e-05 2.02453e-04
+        674    12 -228.391855 -228.391674 1.809298e-04   0.053 1.15564e-05 2.02452e-04
+        675    15 -228.391855 -228.391674 1.806131e-04   0.053 1.15540e-05 2.02451e-04
+        676    12 -228.391857 -228.391674 1.824546e-04   0.053 1.18134e-05 2.02450e-04
+        677    12 -228.391856 -228.391674 1.818910e-04   0.053 1.15503e-05 2.02450e-04
+        678    15 -228.391858 -228.391674 1.838369e-04   0.053 1.15035e-05 2.02449e-04
+        679    12 -228.391858 -228.391674 1.837705e-04   0.053 1.17817e-05 2.02448e-04
+        680    12 -228.391860 -228.391674 1.854389e-04   0.053 1.14999e-05 2.02447e-04
+        681    15 -228.391860 -228.391674 1.853305e-04   0.053 1.14548e-05 2.02446e-04
+        682    10 -228.391861 -228.391674 1.870053e-04   0.053 1.18066e-05 2.02445e-04
+        683    11 -228.391861 -228.391674 1.869712e-04   0.053 1.12961e-05 2.02444e-04
+        684    15 -228.391862 -228.391674 1.882255e-04   0.053 1.15539e-05 2.02443e-04
+        685    12 -228.391863 -228.391674 1.884938e-04   0.053 1.17002e-05 2.02443e-04
+        686    15 -228.391864 -228.391674 1.898997e-04   0.053 1.14710e-05 2.02442e-04
+        687    12 -228.391864 -228.391674 1.897024e-04   0.053 1.15559e-05 2.02441e-04
+        688    12 -228.391866 -228.391674 1.918589e-04   0.053 1.13873e-05 2.02440e-04
+        689    15 -228.391866 -228.391674 1.914435e-04   0.053 1.13938e-05 2.02439e-04
+        690    12 -228.391867 -228.391674 1.930413e-04   0.053 1.16747e-05 2.02438e-04
+        691    12 -228.391867 -228.391674 1.932486e-04   0.053 1.13994e-05 2.02437e-04
+        692    15 -228.391869 -228.391674 1.945015e-04   0.053 1.13646e-05 2.02437e-04
+        693    12 -228.391869 -228.391674 1.943136e-04   0.053 1.16107e-05 2.02436e-04
+        694    15 -228.391870 -228.391674 1.962496e-04   0.053 1.12556e-05 2.02435e-04
+        695    11 -228.391871 -228.391674 1.963293e-04   0.053 1.14744e-05 2.02434e-04
+        696    15 -228.391872 -228.391674 1.975950e-04   0.053 1.13010e-05 2.02433e-04
+        697    12 -228.391872 -228.391674 1.973362e-04   0.053 1.15085e-05 2.02432e-04
+        698    15 -228.391874 -228.391674 1.994381e-04   0.053 1.12573e-05 2.02432e-04
+        699    10 -228.391873 -228.391674 1.991770e-04   0.053 1.15846e-05 2.02431e-04
+        700    14 -228.391875 -228.391674 2.007321e-04   0.053 1.11864e-05 2.02430e-04
+        701    12 -228.391875 -228.391674 2.010599e-04   0.053 1.15450e-05 2.02429e-04
+        702    15 -228.391876 -228.391674 2.022087e-04   0.053 1.11852e-05 2.02428e-04
+        703    10 -228.391877 -228.391674 2.024297e-04   0.053 1.15606e-05 2.02427e-04
+        704    14 -228.391878 -228.391674 2.036988e-04   0.053 1.11366e-05 2.02426e-04
+        705    12 -228.391878 -228.391674 2.041689e-04   0.053 1.15135e-05 2.02426e-04
+        706    12 -228.391880 -228.391674 2.054086e-04   0.053 1.12171e-05 2.02425e-04
+        707    15 -228.391880 -228.391674 2.055258e-04   0.053 1.12436e-05 2.02424e-04
+        708    12 -228.391882 -228.391674 2.074966e-04   0.053 1.14536e-05 2.02423e-04
+        709    12 -228.391881 -228.391674 2.066855e-04   0.053 1.12093e-05 2.02422e-04
+        710    12 -228.391883 -228.391674 2.089613e-04   0.053 1.11975e-05 2.02421e-04
+        711    13 -228.391883 -228.391674 2.085034e-04   0.053 1.11028e-05 2.02421e-04
+        712    15 -228.391884 -228.391674 2.100674e-04   0.053 1.13169e-05 2.02420e-04
+        713    10 -228.391884 -228.391674 2.102239e-04   0.053 1.14365e-05 2.02419e-04
+        714    12 -228.391886 -228.391674 2.121819e-04   0.053 1.09948e-05 2.02418e-04
+        715    14 -228.391886 -228.391674 2.115185e-04   0.053 1.11489e-05 2.02417e-04
+        716    12 -228.391887 -228.391674 2.132860e-04   0.053 1.13923e-05 2.02416e-04
+        717    13 -228.391887 -228.391674 2.132483e-04   0.053 1.09474e-05 2.02416e-04
+        718    12 -228.391889 -228.391674 2.150070e-04   0.053 1.12861e-05 2.02415e-04
+        719    15 -228.391889 -228.391674 2.147328e-04   0.053 1.10418e-05 2.02414e-04
+        720    11 -228.391890 -228.391674 2.161990e-04   0.053 1.12675e-05 2.02413e-04
+        721    15 -228.391891 -228.391674 2.164743e-04   0.053 1.09863e-05 2.02412e-04
+        722    10 -228.391892 -228.391674 2.174218e-04   0.053 1.12553e-05 2.02412e-04
+        723    13 -228.391893 -228.391674 2.184175e-04   0.053 1.08913e-05 2.02411e-04
+        724    15 -228.391893 -228.391674 2.188187e-04   0.053 1.12097e-05 2.02410e-04
+        725    10 -228.391894 -228.391674 2.202007e-04   0.053 1.13507e-05 2.02409e-04
+        726    12 -228.391894 -228.391674 2.199130e-04   0.053 1.08784e-05 2.02408e-04
+        727    14 -228.391896 -228.391674 2.217716e-04   0.053 1.10729e-05 2.02407e-04
+        728    12 -228.391896 -228.391674 2.219024e-04   0.053 1.12328e-05 2.02407e-04
+        729    15 -228.391897 -228.391674 2.231774e-04   0.053 1.09306e-05 2.02406e-04
+        730    11 -228.391898 -228.391674 2.239750e-04   0.053 1.11244e-05 2.02405e-04
+        731    15 -228.391898 -228.391674 2.240965e-04   0.053 1.09239e-05 2.02404e-04
+        732    12 -228.391900 -228.391674 2.259820e-04   0.053 1.11394e-05 2.02403e-04
+        733    12 -228.391899 -228.391674 2.252536e-04   0.053 1.09966e-05 2.02403e-04
+        734    15 -228.391901 -228.391674 2.272694e-04   0.053 1.09209e-05 2.02402e-04
+        735    15 -228.391901 -228.391674 2.272636e-04   0.053 1.11792e-05 2.02401e-04
+        736    12 -228.391903 -228.391674 2.290469e-04   0.053 1.09948e-05 2.02400e-04
+        737    12 -228.391903 -228.391674 2.284089e-04   0.053 1.08961e-05 2.02399e-04
+        738    11 -228.391904 -228.391674 2.302529e-04   0.053 1.09229e-05 2.02399e-04
+        739    13 -228.391905 -228.391674 2.304019e-04   0.053 1.08265e-05 2.02398e-04
+        740    15 -228.391906 -228.391674 2.317241e-04   0.053 1.11121e-05 2.02397e-04
+        741    12 -228.391906 -228.391674 2.315790e-04   0.053 1.10625e-05 2.02396e-04
+        742    10 -228.391908 -228.391674 2.335799e-04   0.053 1.09589e-05 2.02395e-04
+        743    14 -228.391908 -228.391674 2.334542e-04   0.053 1.06348e-05 2.02395e-04
+        744    11 -228.391909 -228.391674 2.347025e-04   0.053 1.11957e-05 2.02394e-04
+        745    12 -228.391909 -228.391674 2.344072e-04   0.053 1.08092e-05 2.02393e-04
+        746    15 -228.391911 -228.391674 2.367329e-04   0.053 1.08953e-05 2.02392e-04
+        747    11 -228.391911 -228.391674 2.366391e-04   0.053 1.09842e-05 2.02391e-04
+        748    15 -228.391912 -228.391674 2.378964e-04   0.053 1.07557e-05 2.02391e-04
+        749    10 -228.391913 -228.391674 2.387006e-04   0.053 1.09311e-05 2.02390e-04
+        750    15 -228.391913 -228.391674 2.387754e-04   0.053 1.07912e-05 2.02389e-04
+        751    12 -228.391915 -228.391674 2.406207e-04   0.053 1.09933e-05 2.02388e-04
+        752    15 -228.391915 -228.391674 2.403006e-04   0.053 1.07141e-05 2.02388e-04
+        753    10 -228.391916 -228.391674 2.419528e-04   0.053 1.09902e-05 2.02387e-04
+        754    14 -228.391916 -228.391674 2.420304e-04   0.053 1.07085e-05 2.02386e-04
+        755    12 -228.391917 -228.391674 2.430804e-04   0.053 1.10071e-05 2.02385e-04
+        756    12 -228.391918 -228.391674 2.438153e-04   0.053 1.07127e-05 2.02384e-04
+        757    14 -228.391918 -228.391674 2.441264e-04   0.053 1.07428e-05 2.02384e-04
+        758    12 -228.391920 -228.391674 2.461353e-04   0.053 1.09539e-05 2.02383e-04
+        759    12 -228.391920 -228.391674 2.455440e-04   0.053 1.06830e-05 2.02382e-04
+        760    11 -228.391921 -228.391674 2.472811e-04   0.053 1.06784e-05 2.02381e-04
+        761    13 -228.391922 -228.391674 2.476171e-04   0.053 1.06012e-05 2.02381e-04
+        762    15 -228.391923 -228.391674 2.487167e-04   0.053 1.08155e-05 2.02380e-04
+        763    12 -228.391923 -228.391674 2.486944e-04   0.053 1.08658e-05 2.02379e-04
+        764    10 -228.391925 -228.391674 2.506097e-04   0.053 1.07823e-05 2.02378e-04
+        765    11 -228.391925 -228.391674 2.505470e-04   0.053 1.04563e-05 2.02377e-04
+        766    15 -228.391926 -228.391674 2.518072e-04   0.053 1.08659e-05 2.02377e-04
+        767    10 -228.391926 -228.391674 2.520907e-04   0.053 1.09356e-05 2.02376e-04
+        768    12 -228.391928 -228.391674 2.538727e-04   0.053 1.05608e-05 2.02375e-04
+        769    15 -228.391928 -228.391674 2.534304e-04   0.053 1.06058e-05 2.02374e-04
+        770    10 -228.391929 -228.391674 2.551394e-04   0.053 1.08572e-05 2.02374e-04
+        771    12 -228.391929 -228.391674 2.548492e-04   0.053 1.05347e-05 2.02373e-04
+        772    14 -228.391931 -228.391674 2.566106e-04   0.053 1.06009e-05 2.02372e-04
+        773    12 -228.391931 -228.391674 2.567439e-04   0.053 1.07657e-05 2.02371e-04
+        774    15 -228.391932 -228.391674 2.580559e-04   0.053 1.04692e-05 2.02371e-04
+        775    10 -228.391932 -228.391674 2.582103e-04   0.053 1.08298e-05 2.02370e-04
+        776    12 -228.391934 -228.391674 2.600752e-04   0.053 1.04539e-05 2.02369e-04
+        777    12 -228.391934 -228.391674 2.593619e-04   0.053 1.06897e-05 2.02368e-04
+        778    14 -228.391936 -228.391674 2.613680e-04   0.053 1.05746e-05 2.02367e-04
+        779    11 -228.391935 -228.391674 2.611572e-04   0.053 1.07062e-05 2.02367e-04
+        780    12 -228.391937 -228.391674 2.629783e-04   0.053 1.04668e-05 2.02366e-04
+        781    12 -228.391937 -228.391674 2.624999e-04   0.053 1.05348e-05 2.02365e-04
+        782    13 -228.391939 -228.391674 2.644052e-04   0.053 1.04001e-05 2.02364e-04
+        783    12 -228.391938 -228.391674 2.642198e-04   0.053 1.07375e-05 2.02364e-04
+        784    13 -228.391940 -228.391674 2.660547e-04   0.053 1.03202e-05 2.02363e-04
+        785    14 -228.391940 -228.391674 2.660693e-04   0.053 1.05428e-05 2.02362e-04
+        786    10 -228.391942 -228.391674 2.673486e-04   0.053 1.07048e-05 2.02361e-04
+        787    12 -228.391941 -228.391674 2.671303e-04   0.053 1.02975e-05 2.02361e-04
+        788    10 -228.391944 -228.391674 2.693026e-04   0.053 1.06629e-05 2.02360e-04
+        789    12 -228.391943 -228.391674 2.688037e-04   0.053 1.03547e-05 2.02359e-04
+        790    14 -228.391945 -228.391674 2.705565e-04   0.053 1.05842e-05 2.02358e-04
+        791    12 -228.391945 -228.391674 2.705599e-04   0.053 1.05888e-05 2.02358e-04
+        792    12 -228.391947 -228.391674 2.723609e-04   0.053 1.03651e-05 2.02357e-04
+        793    12 -228.391946 -228.391674 2.718425e-04   0.053 1.03328e-05 2.02356e-04
+        794    12 -228.391948 -228.391674 2.740670e-04   0.053 1.05154e-05 2.02355e-04
+        795    13 -228.391948 -228.391674 2.736424e-04   0.053 1.02535e-05 2.02355e-04
+        796    12 -228.391950 -228.391674 2.754567e-04   0.053 1.06381e-05 2.02354e-04
+        797    13 -228.391950 -228.391674 2.752561e-04   0.053 1.01823e-05 2.02353e-04
+        798    12 -228.391951 -228.391674 2.769200e-04   0.053 1.05935e-05 2.02353e-04
+        799    13 -228.391951 -228.391674 2.766446e-04   0.053 1.01559e-05 2.02352e-04
+        800    15 -228.391953 -228.391674 2.782795e-04   0.053 1.04660e-05 2.02351e-04
+        801    11 -228.391953 -228.391674 2.785378e-04   0.053 1.04411e-05 2.02350e-04
+        802    12 -228.391954 -228.391674 2.801224e-04   0.053 1.03265e-05 2.02350e-04
+        803    12 -228.391954 -228.391674 2.795334e-04   0.053 1.02911e-05 2.02349e-04
+        804    15 -228.391956 -228.391674 2.815284e-04   0.053 1.03520e-05 2.02348e-04
+        805    10 -228.391956 -228.391674 2.813903e-04   0.053 1.06008e-05 2.02347e-04
+        806    11 -228.391957 -228.391674 2.826785e-04   0.053 1.01864e-05 2.02347e-04
+        807    14 -228.391958 -228.391674 2.835114e-04   0.053 1.02713e-05 2.02346e-04
+        808    12 -228.391958 -228.391674 2.841102e-04   0.053 1.04404e-05 2.02345e-04
+        809    10 -228.391959 -228.391674 2.849111e-04   0.053 1.03729e-05 2.02344e-04
+        810    15 -228.391960 -228.391674 2.852461e-04   0.053 1.01410e-05 2.02344e-04
+        811    12 -228.391961 -228.391674 2.868435e-04   0.053 1.05248e-05 2.02343e-04
+        812    12 -228.391961 -228.391674 2.868624e-04   0.053 1.01875e-05 2.02342e-04
+        813    15 -228.391963 -228.391674 2.882896e-04   0.053 1.01560e-05 2.02342e-04
+        814    12 -228.391963 -228.391674 2.882979e-04   0.053 1.03611e-05 2.02341e-04
+        815    11 -228.391964 -228.391674 2.898711e-04   0.053 1.01626e-05 2.02340e-04
+        816    13 -228.391964 -228.391674 2.900782e-04   0.053 9.99769e-06 2.02339e-04
+        817    15 -228.391966 -228.391674 2.913725e-04   0.053 1.03176e-05 2.02339e-04
+        818    11 -228.391967 -228.391674 2.922512e-04   0.053 1.03262e-05 2.02338e-04
+        819    10 -228.391967 -228.391674 2.922572e-04   0.053 1.02500e-05 2.02337e-04
+        820    13 -228.391968 -228.391674 2.935679e-04   0.053 9.91750e-06 2.02337e-04
+        821    15 -228.391968 -228.391674 2.940521e-04   0.053 1.04267e-05 2.02336e-04
+        822    10 -228.391969 -228.391674 2.951358e-04   0.053 1.03533e-05 2.02335e-04
+        823    12 -228.391969 -228.391674 2.949622e-04   0.053 1.00236e-05 2.02334e-04
+        824    10 -228.391971 -228.391674 2.971241e-04   0.053 1.03273e-05 2.02334e-04
+        825    14 -228.391971 -228.391674 2.969534e-04   0.053 9.95901e-06 2.02333e-04
+        826    11 -228.391973 -228.391674 2.983626e-04   0.053 1.04489e-05 2.02332e-04
+        827    12 -228.391973 -228.391674 2.984597e-04   0.053 1.00144e-05 2.02332e-04
+        828    15 -228.391974 -228.391674 2.999377e-04   0.053 1.00524e-05 2.02331e-04
+        829    11 -228.391975 -228.391674 3.004999e-04   0.053 1.02322e-05 2.02330e-04
+        830    13 -228.391976 -228.391674 3.012187e-04   0.053 9.93382e-06 2.02329e-04
+        831    11 -228.391976 -228.391674 3.021387e-04   0.053 1.01876e-05 2.02329e-04
+        832    12 -228.391977 -228.391674 3.024287e-04   0.053 1.00490e-05 2.02328e-04
+        833    15 -228.391978 -228.391674 3.037253e-04   0.053 1.00624e-05 2.02327e-04
+        834    10 -228.391978 -228.391674 3.039910e-04   0.053 1.02985e-05 2.02327e-04
+        835    11 -228.391980 -228.391674 3.052077e-04   0.053 9.88871e-06 2.02326e-04
+        836    13 -228.391980 -228.391674 3.058294e-04   0.053 9.92889e-06 2.02325e-04
+        837    11 -228.391981 -228.391674 3.063385e-04   0.053 1.02252e-05 2.02324e-04
+        838    13 -228.391982 -228.391674 3.078617e-04   0.053 9.84645e-06 2.02324e-04
+        839    12 -228.391982 -228.391674 3.079057e-04   0.053 1.02136e-05 2.02323e-04
+        840    12 -228.391984 -228.391674 3.092884e-04   0.053 9.93988e-06 2.02322e-04
+        841    15 -228.391984 -228.391674 3.093987e-04   0.053 9.98614e-06 2.02322e-04
+        842    10 -228.391985 -228.391674 3.109245e-04   0.053 1.02322e-05 2.02321e-04
+        843    11 -228.391985 -228.391674 3.110181e-04   0.053 9.83083e-06 2.02320e-04
+        844    10 -228.391987 -228.391674 3.123690e-04   0.053 1.01108e-05 2.02320e-04
+        845    13 -228.391987 -228.391674 3.125974e-04   0.053 9.76389e-06 2.02319e-04
+        846    13 -228.391988 -228.391674 3.135544e-04   0.053 1.01522e-05 2.02318e-04
+        847    11 -228.391989 -228.391674 3.149034e-04   0.053 9.97471e-06 2.02318e-04
+        848    13 -228.391989 -228.391674 3.146618e-04   0.053 9.75597e-06 2.02317e-04
+        849    12 -228.391990 -228.391674 3.161440e-04   0.053 1.00842e-05 2.02316e-04
+        850    12 -228.391991 -228.391674 3.163126e-04   0.053 9.88014e-06 2.02315e-04
+        851    15 -228.391992 -228.391674 3.177275e-04   0.053 9.87605e-06 2.02315e-04
+        852    11 -228.391992 -228.391674 3.181122e-04   0.053 1.00602e-05 2.02314e-04
+        853    11 -228.391993 -228.391674 3.191203e-04   0.053 9.83917e-06 2.02313e-04
+        854    15 -228.391994 -228.391674 3.195117e-04   0.053 9.79818e-06 2.02313e-04
+        855    12 -228.391996 -228.391674 3.212243e-04   0.053 1.00792e-05 2.02312e-04
+        856    10 -228.391995 -228.391674 3.207170e-04   0.053 9.92536e-06 2.02311e-04
+        857    13 -228.391997 -228.391674 3.223743e-04   0.053 9.67154e-06 2.02311e-04
+        858    12 -228.391997 -228.391674 3.222074e-04   0.053 1.02104e-05 2.02310e-04
+        859    12 -228.391999 -228.391674 3.243623e-04   0.053 9.76132e-06 2.02309e-04
+        860    12 -228.391998 -228.391674 3.236816e-04   0.053 1.00305e-05 2.02309e-04
+        861    12 -228.392000 -228.391674 3.259352e-04   0.053 9.83509e-06 2.02308e-04
+        862    13 -228.392000 -228.391674 3.255545e-04   0.053 9.74805e-06 2.02307e-04
+        863    12 -228.392002 -228.391674 3.273163e-04   0.053 9.96417e-06 2.02307e-04
+        864    11 -228.392002 -228.391674 3.272721e-04   0.053 9.75970e-06 2.02306e-04
+        865    13 -228.392003 -228.391674 3.283531e-04   0.053 9.65030e-06 2.02305e-04
+        866    15 -228.392003 -228.391674 3.289087e-04   0.053 9.86922e-06 2.02305e-04
+        867    11 -228.392004 -228.391674 3.291747e-04   0.053 9.91961e-06 2.02304e-04
+        868    10 -228.392006 -228.391674 3.314513e-04   0.053 9.88006e-06 2.02303e-04
+        869    13 -228.392005 -228.391674 3.308846e-04   0.053 9.52284e-06 2.02303e-04
+        870    12 -228.392007 -228.391674 3.326537e-04   0.053 1.01336e-05 2.02302e-04
+        871    12 -228.392007 -228.391674 3.323839e-04   0.053 9.65024e-06 2.02301e-04
+        872    12 -228.392009 -228.391674 3.343470e-04   0.053 9.93600e-06 2.02300e-04
+        873    13 -228.392008 -228.391674 3.340322e-04   0.053 9.56174e-06 2.02300e-04
+        874    12 -228.392010 -228.391674 3.356510e-04   0.053 9.96114e-06 2.02299e-04
+        875    13 -228.392010 -228.391674 3.355574e-04   0.053 9.51050e-06 2.02298e-04
+        876    15 -228.392011 -228.391674 3.371104e-04   0.053 9.78455e-06 2.02298e-04
+        877     9 -228.392012 -228.391674 3.372822e-04   0.053 9.82727e-06 2.02297e-04
+        878    12 -228.392013 -228.391674 3.389576e-04   0.053 9.56738e-06 2.02296e-04
+        879    12 -228.392013 -228.391674 3.385100e-04   0.053 9.78567e-06 2.02296e-04
+        880    12 -228.392015 -228.391674 3.405832e-04   0.053 9.72853e-06 2.02295e-04
+        881    11 -228.392015 -228.391674 3.402768e-04   0.053 9.74395e-06 2.02294e-04
+        882    13 -228.392016 -228.391674 3.416513e-04   0.053 9.52312e-06 2.02294e-04
+        883    15 -228.392016 -228.391674 3.420251e-04   0.053 9.77167e-06 2.02293e-04
+        884    12 -228.392018 -228.391674 3.436309e-04   0.053 9.73720e-06 2.02292e-04
+        885    10 -228.392018 -228.391674 3.432622e-04   0.053 9.71340e-06 2.02292e-04
+        886    12 -228.392019 -228.391674 3.450922e-04   0.053 9.49869e-06 2.02291e-04
+        887    13 -228.392019 -228.391674 3.450136e-04   0.053 9.63613e-06 2.02291e-04
+        888    12 -228.392021 -228.391674 3.467474e-04   0.053 9.79131e-06 2.02290e-04
+        889    11 -228.392021 -228.391674 3.464753e-04   0.053 9.60339e-06 2.02289e-04
+        890    13 -228.392022 -228.391674 3.478837e-04   0.053 9.44514e-06 2.02289e-04
+        891    12 -228.392022 -228.391674 3.479999e-04   0.053 9.79202e-06 2.02288e-04
+        892    13 -228.392024 -228.391674 3.495790e-04   0.053 9.40233e-06 2.02287e-04
+        893    13 -228.392024 -228.391674 3.495753e-04   0.053 9.58256e-06 2.02287e-04
+        894    12 -228.392026 -228.391674 3.512936e-04   0.053 9.66048e-06 2.02286e-04
+        895    12 -228.392025 -228.391674 3.509245e-04   0.053 9.59112e-06 2.02285e-04
+        896    12 -228.392027 -228.391674 3.529047e-04   0.053 9.60749e-06 2.02285e-04
+        897    12 -228.392027 -228.391674 3.523711e-04   0.053 9.63947e-06 2.02284e-04
+        898    13 -228.392029 -228.391674 3.542197e-04   0.053 9.42475e-06 2.02283e-04
+        899    12 -228.392029 -228.391674 3.542431e-04   0.053 9.73715e-06 2.02283e-04
+        900    12 -228.392030 -228.391674 3.558245e-04   0.053 9.47632e-06 2.02282e-04
+        901    12 -228.392030 -228.391674 3.555378e-04   0.053 9.59263e-06 2.02281e-04
+        902    11 -228.392032 -228.391674 3.572744e-04   0.053 9.49387e-06 2.02281e-04
+        903    15 -228.392032 -228.391674 3.574416e-04   0.053 9.45478e-06 2.02280e-04
+        904    10 -228.392033 -228.391674 3.583466e-04   0.053 9.66488e-06 2.02279e-04
+        905    11 -228.392033 -228.391674 3.586118e-04   0.053 9.38408e-06 2.02279e-04
+        906    12 -228.392035 -228.391674 3.606148e-04   0.053 9.51459e-06 2.02278e-04
+        907    13 -228.392035 -228.391674 3.603584e-04   0.053 9.34975e-06 2.02278e-04
+        908    12 -228.392036 -228.391674 3.619393e-04   0.053 9.65370e-06 2.02277e-04
+        909    12 -228.392036 -228.391674 3.619857e-04   0.053 9.44228e-06 2.02276e-04
+        910    12 -228.392038 -228.391674 3.635445e-04   0.053 9.53279e-06 2.02276e-04
+        911    12 -228.392038 -228.391674 3.633068e-04   0.053 9.48188e-06 2.02275e-04
+        912    13 -228.392039 -228.391674 3.651212e-04   0.053 9.32207e-06 2.02274e-04
+        913    12 -228.392040 -228.391674 3.652528e-04   0.053 9.60916e-06 2.02274e-04
+        914    12 -228.392041 -228.391674 3.664686e-04   0.053 9.35665e-06 2.02273e-04
+        915    15 -228.392041 -228.391674 3.667416e-04   0.053 9.36788e-06 2.02272e-04
+        916    10 -228.392043 -228.391674 3.681655e-04   0.053 9.58636e-06 2.02272e-04
+        917    11 -228.392043 -228.391674 3.683707e-04   0.053 9.26304e-06 2.02271e-04
+        918    10 -228.392044 -228.391674 3.695336e-04   0.053 9.49926e-06 2.02270e-04
+        919    12 -228.392044 -228.391674 3.694037e-04   0.053 9.35557e-06 2.02270e-04
+        920    13 -228.392046 -228.391674 3.712128e-04   0.053 9.38485e-06 2.02269e-04
+        921    12 -228.392046 -228.391674 3.711648e-04   0.053 9.51992e-06 2.02269e-04
+        922    12 -228.392047 -228.391674 3.730129e-04   0.053 9.32738e-06 2.02268e-04
+        923    13 -228.392047 -228.391674 3.728455e-04   0.053 9.18273e-06 2.02267e-04
+        924    15 -228.392049 -228.391674 3.742141e-04   0.053 9.39597e-06 2.02267e-04
+        925    11 -228.392049 -228.391674 3.746475e-04   0.053 9.38668e-06 2.02266e-04
+        926    12 -228.392051 -228.391674 3.761522e-04   0.053 9.31337e-06 2.02265e-04
+        927    11 -228.392050 -228.391674 3.757314e-04   0.053 9.25801e-06 2.02265e-04
+        928    12 -228.392052 -228.391674 3.773263e-04   0.053 9.42167e-06 2.02264e-04
+        929    11 -228.392052 -228.391674 3.774590e-04   0.053 9.34146e-06 2.02264e-04
+        930    15 -228.392053 -228.391674 3.788368e-04   0.053 9.28839e-06 2.02263e-04
+        931    10 -228.392054 -228.391674 3.793634e-04   0.053 9.47191e-06 2.02262e-04
+        932    12 -228.392055 -228.391674 3.811020e-04   0.053 9.22028e-06 2.02262e-04
+        933    10 -228.392055 -228.391674 3.801110e-04   0.053 9.53828e-06 2.02261e-04
+        934    12 -228.392057 -228.391674 3.823189e-04   0.053 9.15743e-06 2.02260e-04
+        935    12 -228.392056 -228.391674 3.818704e-04   0.053 9.49711e-06 2.02260e-04
+        936    12 -228.392058 -228.391674 3.838725e-04   0.053 9.23887e-06 2.02259e-04
+        937    12 -228.392058 -228.391674 3.833694e-04   0.053 9.38058e-06 2.02259e-04
+        938    12 -228.392060 -228.391674 3.854478e-04   0.053 9.26273e-06 2.02258e-04
+        939    11 -228.392060 -228.391674 3.851792e-04   0.053 9.28249e-06 2.02257e-04
+        940    13 -228.392061 -228.391674 3.865002e-04   0.053 9.07963e-06 2.02257e-04
+        941    12 -228.392061 -228.391674 3.865521e-04   0.053 9.40231e-06 2.02256e-04
+        942    11 -228.392063 -228.391674 3.880879e-04   0.053 9.16202e-06 2.02255e-04
+        943    13 -228.392063 -228.391674 3.883240e-04   0.053 9.12597e-06 2.02255e-04
+        944    10 -228.392064 -228.391674 3.897978e-04   0.053 9.42624e-06 2.02254e-04
+        945    12 -228.392064 -228.391674 3.896144e-04   0.053 9.11948e-06 2.02254e-04
+        946    13 -228.392066 -228.391674 3.913090e-04   0.053 9.15677e-06 2.02253e-04
+        947    12 -228.392066 -228.391674 3.913847e-04   0.053 9.32068e-06 2.02252e-04
+        948    12 -228.392067 -228.391674 3.929710e-04   0.053 9.15351e-06 2.02252e-04
+        949    12 -228.392067 -228.391674 3.927091e-04   0.053 9.20258e-06 2.02251e-04
+        950    11 -228.392069 -228.391674 3.944008e-04   0.053 9.17165e-06 2.02251e-04
+        951    13 -228.392069 -228.391674 3.944360e-04   0.053 9.03810e-06 2.02250e-04
+        952    12 -228.392070 -228.391674 3.960264e-04   0.053 9.32561e-06 2.02249e-04
+        953    12 -228.392070 -228.391674 3.958835e-04   0.053 9.09936e-06 2.02249e-04
+        954    12 -228.392072 -228.391674 3.977297e-04   0.053 9.19667e-06 2.02248e-04
+        955    13 -228.392072 -228.391674 3.975440e-04   0.053 8.98749e-06 2.02248e-04
+        956    12 -228.392073 -228.391674 3.990535e-04   0.053 9.28505e-06 2.02247e-04
+        957    12 -228.392074 -228.391674 3.990743e-04   0.053 9.07391e-06 2.02246e-04
+        958    12 -228.392075 -228.391674 4.007434e-04   0.053 9.17969e-06 2.02246e-04
+        959    12 -228.392075 -228.391674 4.004817e-04   0.053 9.14266e-06 2.02245e-04
+        960    12 -228.392077 -228.391674 4.023807e-04   0.053 9.17572e-06 2.02245e-04
+        961    12 -228.392076 -228.391674 4.019617e-04   0.053 9.13944e-06 2.02244e-04
+        962    12 -228.392078 -228.391674 4.039749e-04   0.053 9.14671e-06 2.02243e-04
+        963    13 -228.392078 -228.391674 4.037584e-04   0.053 8.94510e-06 2.02243e-04
+        964    12 -228.392080 -228.391674 4.053427e-04   0.053 9.20488e-06 2.02242e-04
+        965    11 -228.392080 -228.391674 4.053896e-04   0.053 8.96452e-06 2.02241e-04
+        966    13 -228.392081 -228.391674 4.068493e-04   0.053 8.94228e-06 2.02241e-04
+        967    10 -228.392081 -228.391674 4.068459e-04   0.053 9.26402e-06 2.02240e-04
+        968    12 -228.392083 -228.391674 4.085580e-04   0.053 8.96007e-06 2.02240e-04
+        969    10 -228.392083 -228.391674 4.082523e-04   0.053 9.25896e-06 2.02239e-04
+        970    13 -228.392084 -228.391674 4.097827e-04   0.053 8.82248e-06 2.02239e-04
+        971    12 -228.392084 -228.391674 4.097662e-04   0.053 9.34151e-06 2.02238e-04
+        972    13 -228.392086 -228.391674 4.114167e-04   0.053 8.79675e-06 2.02237e-04
+        973    12 -228.392086 -228.391674 4.114005e-04   0.053 9.21166e-06 2.02237e-04
+        974    11 -228.392087 -228.391674 4.129663e-04   0.053 8.87545e-06 2.02236e-04
+        975    13 -228.392087 -228.391674 4.129441e-04   0.053 8.95098e-06 2.02236e-04
+        976    12 -228.392089 -228.391674 4.145676e-04   0.053 9.09725e-06 2.02235e-04
+        977    13 -228.392089 -228.391674 4.145698e-04   0.053 8.84774e-06 2.02234e-04
+        978    10 -228.392091 -228.391674 4.161118e-04   0.053 9.15206e-06 2.02234e-04
+        979    12 -228.392090 -228.391674 4.159236e-04   0.053 8.88822e-06 2.02233e-04
+        980    12 -228.392092 -228.391674 4.178728e-04   0.053 9.14792e-06 2.02233e-04
+        981    12 -228.392092 -228.391675 4.174239e-04   0.053 8.94938e-06 2.02232e-04
+        982    12 -228.392094 -228.391674 4.194234e-04   0.053 9.05571e-06 2.02231e-04
+        983    12 -228.392093 -228.391675 4.189764e-04   0.053 8.95955e-06 2.02231e-04
+        984    11 -228.392095 -228.391674 4.206937e-04   0.053 8.97211e-06 2.02230e-04
+        985    12 -228.392095 -228.391675 4.205803e-04   0.053 8.95921e-06 2.02230e-04
+        986    12 -228.392097 -228.391674 4.225525e-04   0.053 9.01559e-06 2.02229e-04
+        987    12 -228.392097 -228.391675 4.220982e-04   0.053 8.94510e-06 2.02228e-04
+        988    12 -228.392099 -228.391674 4.240738e-04   0.053 8.95463e-06 2.02228e-04
+        989    11 -228.392098 -228.391674 4.238920e-04   0.053 8.90546e-06 2.02227e-04
+        990    12 -228.392100 -228.391674 4.255812e-04   0.053 8.93957e-06 2.02227e-04
+        991    12 -228.392100 -228.391675 4.251456e-04   0.053 8.97154e-06 2.02226e-04
+        992    12 -228.392102 -228.391674 4.271462e-04   0.053 8.91691e-06 2.02226e-04
+        993    12 -228.392101 -228.391675 4.267174e-04   0.053 8.93296e-06 2.02225e-04
+        994    12 -228.392103 -228.391674 4.286918e-04   0.053 8.89906e-06 2.02224e-04
+        995    13 -228.392103 -228.391675 4.285408e-04   0.053 8.73590e-06 2.02224e-04
+        996    12 -228.392105 -228.391674 4.301068e-04   0.053 8.99665e-06 2.02223e-04
+        997    12 -228.392104 -228.391675 4.298992e-04   0.053 8.79885e-06 2.02223e-04
+        998    12 -228.392106 -228.391674 4.317628e-04   0.053 8.88512e-06 2.02222e-04
+        999    11 -228.392106 -228.391675 4.316795e-04   0.053 8.83632e-06 2.02221e-04
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization converged in   3 iterations 
+            Total energy change: -2.273737e-13
+            Final gradient norm: 3.195453e-07
+
+       1000    12 -228.392108 -228.391674 4.337497e-04   0.002 8.89428e-06 2.02221e-04
+       1001     2 -228.392135 -228.391675 4.605917e-04   0.002 1.36344e-04 2.02221e-04
+       1002     0 -228.392113 -228.391675 4.384109e-04   0.002 2.72287e-04 2.02221e-04
+       1003     0 -228.392272 -228.391675 5.978343e-04   0.002 4.20198e-04 2.02221e-04
+       1004     0 -228.391956 -228.391675 2.815718e-04   0.002 4.91785e-04 2.02221e-04
+       1005     3 -228.392537 -228.391674 8.630969e-04   0.002 8.24947e-04 2.02219e-04
+       1006     5 -228.392075 -228.391675 4.004512e-04   0.002 8.50375e-04 2.02218e-04
+       1007     5 -228.392183 -228.391675 5.085099e-04   0.002 9.52778e-04 2.02216e-04
+       1008     5 -228.392073 -228.391674 3.988663e-04   0.002 1.14406e-03 2.02215e-04
+       1009     7 -228.392783 -228.391674 1.109461e-03   0.002 1.28633e-03 2.02213e-04
+       1010     7 -228.392063 -228.391675 3.883640e-04   0.002 1.24518e-03 2.02208e-04
+       1011     8 -228.392297 -228.391675 6.225523e-04   0.002 1.18107e-03 2.02203e-04
+       1012     6 -228.392347 -228.391674 6.729362e-04   0.002 1.46182e-03 2.02200e-04
+       1013     8 -228.392485 -228.391675 8.102788e-04   0.002 1.28290e-03 2.02196e-04
+       1014     8 -228.392155 -228.391675 4.805820e-04   0.002 1.45554e-03 2.02191e-04
+       1015     8 -228.392398 -228.391675 7.233687e-04   0.002 1.41726e-03 2.02187e-04
+       1016     8 -228.392305 -228.391675 6.308673e-04   0.002 1.58661e-03 2.02182e-04
+       1017     8 -228.392450 -228.391675 7.754446e-04   0.002 1.62377e-03 2.02177e-04
+       1018     8 -228.392397 -228.391674 7.232167e-04   0.002 1.76337e-03 2.02172e-04
+       1019     8 -228.392352 -228.391675 6.768661e-04   0.002 1.81360e-03 2.02167e-04
+       1020     8 -228.392345 -228.391674 6.703780e-04   0.002 1.70368e-03 2.02162e-04
+       1021     8 -228.392492 -228.391675 8.171193e-04   0.002 1.93589e-03 2.02156e-04
+       1022     8 -228.392498 -228.391674 8.240085e-04   0.002 1.92793e-03 2.02151e-04
+       1023     7 -228.392560 -228.391675 8.857176e-04   0.002 1.96753e-03 2.02145e-04
+       1024     8 -228.392462 -228.391674 7.871221e-04   0.002 2.10016e-03 2.02140e-04
+       1025     8 -228.392655 -228.391675 9.796805e-04   0.002 2.00957e-03 2.02134e-04
+       1026     8 -228.392470 -228.391675 7.954805e-04   0.002 2.17846e-03 2.02128e-04
+       1027     8 -228.392435 -228.391675 7.593072e-04   0.002 2.16051e-03 2.02122e-04
+       1028     8 -228.392440 -228.391675 7.651031e-04   0.002 2.22084e-03 2.02117e-04
+       1029     8 -228.392620 -228.391675 9.450826e-04   0.002 2.27958e-03 2.02111e-04
+       1030    10 -228.392573 -228.391675 8.981207e-04   0.002 2.14232e-03 2.02104e-04
+       1031    10 -228.392613 -228.391675 9.382635e-04   0.002 2.32371e-03 2.02097e-04
+       1032    10 -228.392670 -228.391674 9.952801e-04   0.002 2.25870e-03 2.02090e-04
+       1033    10 -228.392561 -228.391675 8.859104e-04   0.002 2.38361e-03 2.02084e-04
+       1034    10 -228.392796 -228.391674 1.121910e-03   0.002 2.35568e-03 2.02078e-04
+       1035    10 -228.392575 -228.391675 8.995352e-04   0.002 2.42422e-03 2.02071e-04
+       1036    10 -228.392808 -228.391675 1.133602e-03   0.002 2.41794e-03 2.02064e-04
+       1037    10 -228.392617 -228.391675 9.413609e-04   0.002 2.46597e-03 2.02058e-04
+       1038    10 -228.392840 -228.391675 1.165168e-03   0.002 2.46965e-03 2.02051e-04
+       1039    10 -228.392650 -228.391676 9.741806e-04   0.002 2.50776e-03 2.02044e-04
+       1040    10 -228.392878 -228.391675 1.203243e-03   0.002 2.51218e-03 2.02038e-04
+       1041    10 -228.392686 -228.391676 1.010654e-03   0.002 2.54472e-03 2.02031e-04
+       1042    10 -228.392918 -228.391675 1.242922e-03   0.002 2.54930e-03 2.02024e-04
+       1043    10 -228.392724 -228.391675 1.048329e-03   0.002 2.57501e-03 2.02018e-04
+       1044    10 -228.392957 -228.391675 1.282775e-03   0.002 2.58226e-03 2.02011e-04
+       1045    10 -228.392763 -228.391675 1.088007e-03   0.002 2.60039e-03 2.02004e-04
+       1046    10 -228.387770 -228.391675 3.904796e-03   0.002 3.39337e-02 1.88765e-04
+       1047    16 -228.381254 -228.391746 1.049216e-02   0.002 7.44349e-02 1.80827e-04
+       1048    17 -228.376976 -228.391874 1.489751e-02   0.002 1.00880e-01 1.75078e-04
+       1049    15 -228.375918 -228.392027 1.610926e-02   0.002 1.06323e-01 1.72735e-04
+       1050    15 -228.378641 -228.392169 1.352792e-02   0.002 8.96803e-02 1.73909e-04
+       1051    14 -228.384021 -228.392272 8.250917e-03   0.002 5.57860e-02 1.77260e-04
+       1052    13 -228.390502 -228.392317 1.814471e-03   0.002 1.53998e-02 1.79392e-04
+       1053    13 -228.396770 -228.392305 4.464558e-03   0.002 2.29961e-02 1.78755e-04
+       1054    15 -228.401135 -228.392245 8.890351e-03   0.002 5.14381e-02 1.76142e-04
+       1055    15 -228.403675 -228.392155 1.151926e-02   0.002 6.67031e-02 1.73406e-04
+       1056    15 -228.403934 -228.392056 1.187828e-02   0.002 6.83646e-02 1.72125e-04
+       1057    15 -228.393426 -228.391966 1.459728e-03   0.002 1.85822e-02 1.45930e-04
+       1058    19 -228.383862 -228.392017 8.155175e-03   0.002 6.20000e-02 1.33782e-04
+       1059    18 -228.375306 -228.392145 1.683855e-02   0.002 1.11087e-01 1.24520e-04
+       1060    15 -228.369639 -228.392330 2.269109e-02   0.002 1.46856e-01 1.09661e-04
+       1061    18 -228.366658 -228.392551 2.589360e-02   0.002 1.65241e-01 9.21950e-05
+       1062    20 -228.366871 -228.392782 2.591120e-02   0.002 1.64444e-01 8.52519e-05
+       1063    20 -228.369697 -228.392997 2.329961e-02   0.002 1.46116e-01 9.14962e-05
+       1064    15 -228.374940 -228.393172 1.823231e-02   0.002 1.13497e-01 1.02068e-04
+       1065    16 -228.381710 -228.393294 1.158354e-02   0.002 7.11112e-02 1.11010e-04
+       1066    17 -228.389285 -228.393352 4.067294e-03   0.002 2.40488e-02 1.15966e-04
+       1067    15 -228.396688 -228.393344 3.343403e-03   0.002 2.29362e-02 1.15434e-04
+       1068    15 -228.403300 -228.393277 1.002294e-02   0.002 6.39382e-02 1.09436e-04
+       1069    15 -228.408330 -228.393160 1.516964e-02   0.002 9.54629e-02 1.00117e-04
+       1070    15 -228.411408 -228.393011 1.839780e-02   0.002 1.14705e-01 9.10327e-05
+       1071    15 -228.412350 -228.392845 1.950501e-02   0.002 1.20446e-01 8.57693e-05
+       1072    16 -228.411151 -228.392683 1.846789e-02   0.002 1.12956e-01 8.61295e-05
+       1073    15 -228.408122 -228.392541 1.558114e-02   0.002 9.39242e-02 9.08936e-05
+       1074    15 -228.403678 -228.392434 1.124414e-02   0.002 6.61491e-02 9.69321e-05
+       1075    15 -228.398423 -228.392370 6.053619e-03   0.002 3.31938e-02 1.01352e-04
+       1076    14 -228.392929 -228.392353 5.763871e-04   0.002 1.97261e-03 1.02563e-04
+       1077    14 -228.387799 -228.392382 4.582810e-03   0.002 3.30952e-02 1.00379e-04
+       1078    15 -228.383616 -228.392451 8.834949e-03   0.002 5.93526e-02 9.57259e-05
+       1079    15 -228.380702 -228.392550 1.184824e-02   0.002 7.75106e-02 9.03753e-05
+       1080    15 -228.379299 -228.392667 1.336819e-02   0.002 8.62311e-02 8.63732e-05
+       1081    15 -228.379487 -228.392787 1.329982e-02   0.002 8.51394e-02 8.51625e-05
+       1082    15 -228.381084 -228.392898 1.181351e-02   0.002 7.50794e-02 8.67783e-05
+       1083    15 -228.383900 -228.392988 9.088323e-03   0.002 5.76501e-02 8.99369e-05
+       1084    15 -228.387470 -228.393049 5.579864e-03   0.002 3.52804e-02 9.29416e-05
+       1085    15 -228.391448 -228.393077 1.628813e-03   0.002 1.06749e-02 9.45125e-05
+       1086    15 -228.395290 -228.393071 2.218943e-03   0.002 1.36487e-02 9.41379e-05
+       1087    15 -228.398698 -228.393033 5.664506e-03   0.002 3.47046e-02 9.20740e-05
+       1088    15 -228.401234 -228.392970 8.263656e-03   0.002 5.06651e-02 8.91743e-05
+       1089    15 -228.402783 -228.392891 9.892548e-03   0.002 6.01950e-02 8.65657e-05
+       1090    15 -228.403155 -228.392804 1.035119e-02   0.002 6.26453e-02 8.51955e-05
+       1091    15 -228.402479 -228.392720 9.758528e-03   0.002 5.82818e-02 8.54026e-05
+       1092    15 -228.400808 -228.392648 8.160751e-03   0.002 4.79711e-02 8.67967e-05
+       1093    15 -228.398475 -228.392593 5.881348e-03   0.002 3.32664e-02 8.85442e-05
+       1094    15 -228.395686 -228.392562 3.123868e-03   0.002 1.60013e-02 8.98143e-05
+       1095    15 -228.392853 -228.392555 2.981097e-04   0.002 2.45191e-03 9.01058e-05
+       1096    15 -228.390230 -228.392573 2.342861e-03   0.002 1.84253e-02 8.93617e-05
+       1097    15 -228.388092 -228.392610 4.517869e-03   0.002 3.17769e-02 8.79303e-05
+       1098    15 -228.386627 -228.392663 6.035684e-03   0.002 4.08943e-02 8.63922e-05
+       1099    15 -228.385981 -228.392724 6.742217e-03   0.002 4.50258e-02 8.53224e-05
+       1100    15 -228.386116 -228.392786 6.669696e-03   0.002 4.41103e-02 8.50501e-05
+       1101    15 -228.387030 -228.392843 5.813052e-03   0.002 3.85323e-02 8.55337e-05
+       1102    15 -228.388503 -228.392889 4.385218e-03   0.002 2.92504e-02 8.64236e-05
+       1103    15 -228.390418 -228.392919 2.501212e-03   0.002 1.74663e-02 8.72580e-05
+       1104    15 -228.392466 -228.392933 4.664082e-04   0.002 4.81214e-03 8.76706e-05
+       1105    15 -228.394455 -228.392928 1.527545e-03   0.002 8.13844e-03 8.75118e-05
+       1106    15 -228.396180 -228.392907 3.273273e-03   0.002 1.88429e-02 8.68799e-05
+       1107    15 -228.397493 -228.392874 4.619401e-03   0.002 2.69179e-02 8.60468e-05
+       1108    15 -228.398229 -228.392832 5.396582e-03   0.002 3.15742e-02 8.53363e-05
+       1109    15 -228.398410 -228.392787 5.622653e-03   0.002 3.25848e-02 8.49890e-05
+       1110    15 -228.397987 -228.392744 5.243181e-03   0.002 3.00354e-02 8.50704e-05
+       1111    15 -228.397115 -228.392706 4.409019e-03   0.002 2.44850e-02 8.54629e-05
+       1112    15 -228.395846 -228.392679 3.166765e-03   0.002 1.66904e-02 8.59395e-05
+       1113    15 -228.394414 -228.392663 1.750215e-03   0.002 7.73917e-03 8.62728e-05
+       1114    15 -228.392934 -228.392661 2.729505e-04   0.002 2.44181e-03 8.63242e-05
+       1115    15 -228.391622 -228.392671 1.049523e-03   0.002 1.03274e-02 8.60861e-05
+       1116    14 -228.390504 -228.392691 2.187351e-03   0.002 1.70905e-02 8.56696e-05
+       1117    14 -228.389808 -228.392719 2.910880e-03   0.002 2.15983e-02 8.52432e-05
+       1118    15 -228.389478 -228.392751 3.273391e-03   0.002 2.35404e-02 8.49598e-05
+       1119    15 -228.389618 -228.392784 3.166045e-03   0.002 2.28311e-02 8.48976e-05
+       1120    15 -228.390094 -228.392813 2.718891e-03   0.002 1.97690e-02 8.50358e-05
+       1121    15 -228.390919 -228.392836 1.917095e-03   0.002 1.48022e-02 8.52758e-05
+       1122    15 -228.391897 -228.392852 9.541454e-04   0.002 8.67180e-03 8.54920e-05
+       1123    15 -228.392986 -228.392858 1.280629e-04   0.002 2.52666e-03 8.55855e-05
+       1124    15 -228.393975 -228.392854 1.120803e-03   0.002 5.03618e-03 8.55194e-05
+       1125    15 -228.394876 -228.392843 2.032930e-03   0.002 1.03823e-02 8.53271e-05
+       1126    15 -228.395504 -228.392825 2.678886e-03   0.002 1.43796e-02 8.50887e-05
+       1127    15 -228.395889 -228.392803 3.086149e-03   0.002 1.66315e-02 8.48929e-05
+       1128    15 -228.395923 -228.392780 3.142999e-03   0.002 1.69570e-02 8.48005e-05
+       1129    15 -228.395709 -228.392757 2.952047e-03   0.002 1.54913e-02 8.48236e-05
+       1130    15 -228.395203 -228.392738 2.464201e-03   0.002 1.24759e-02 8.49264e-05
+       1131    15 -228.394567 -228.392725 1.841805e-03   0.002 8.40906e-03 8.50459e-05
+       1132    15 -228.393794 -228.392717 1.076735e-03   0.002 3.93584e-03 8.51208e-05
+       1133    15 -228.393086 -228.392717 3.685461e-04   0.002 2.39615e-03 8.51159e-05
+       1134    14 -228.392361 -228.392723 3.613900e-04   0.002 6.05784e-03 8.50329e-05
+       1135    15 -228.391862 -228.392734 8.722845e-04   0.002 9.35565e-03 8.49052e-05
+       1136    15 -228.391479 -228.392749 1.270200e-03   0.002 1.15493e-02 8.47798e-05
+       1137    15 -228.391380 -228.392766 1.385866e-03   0.002 1.23785e-02 8.46969e-05
+       1138    15 -228.391434 -228.392782 1.348870e-03   0.002 1.18921e-02 8.46747e-05
+       1139    15 -228.391746 -228.392797 1.051465e-03   0.002 1.01780e-02 8.47046e-05
+       1140    15 -228.392140 -228.392809 6.691481e-04   0.002 7.59196e-03 8.47582e-05
+       1141    15 -228.392696 -228.392817 1.200640e-04   0.002 4.52047e-03 8.48011e-05
+       1142    15 -228.393204 -228.392819 3.847054e-04   0.002 2.20961e-03 8.48078e-05
+       1143    15 -228.393772 -228.392817 9.554594e-04   0.002 3.56101e-03 8.47704e-05
+       1144    15 -228.394158 -228.392811 1.347643e-03   0.002 6.00658e-03 8.47002e-05
+       1145    15 -228.394529 -228.392801 1.728203e-03   0.002 7.93339e-03 8.46199e-05
+       1146    15 -228.394640 -228.392790 1.850650e-03   0.002 8.92873e-03 8.45533e-05
+       1147    16 -228.394698 -228.392778 1.920871e-03   0.002 8.99586e-03 8.45141e-05
+       1148    15 -228.394531 -228.392766 1.765026e-03   0.002 8.13721e-03 8.45049e-05
+       1149    15 -228.394289 -228.392757 1.532340e-03   0.002 6.57331e-03 8.45154e-05
+       1150    15 -228.393925 -228.392750 1.174789e-03   0.002 4.58730e-03 8.45273e-05
+       1151    15 -228.393564 -228.392747 8.169452e-04   0.002 2.80635e-03 8.45245e-05
+       1152    15 -228.392762 -228.392748 1.448960e-05   0.002 4.20625e-03 7.88593e-05
+       1153    15 -228.389819 -228.392767 2.947961e-03   0.002 2.62444e-02 5.64715e-05
+       1154    17 -228.387498 -228.392902 5.404859e-03   0.002 4.34724e-02 4.32537e-05
+       1155    18 -228.386128 -228.393084 6.955900e-03   0.002 5.35107e-02 2.56604e-05
+       1156    22 -228.385829 -228.393284 7.454973e-03   0.002 5.56353e-02 7.89506e-06
+       1157    26 -228.386492 -228.393474 6.982236e-03   0.002 5.02033e-02 1.43889e-05
+       1158    23 -228.388045 -228.393631 5.585694e-03   0.002 3.86503e-02 2.89921e-05
+       1159    21 -228.390115 -228.393736 3.620926e-03   0.002 2.30452e-02 3.90187e-05
+       1160    18 -228.392463 -228.393781 1.318250e-03   0.002 6.16303e-03 4.31852e-05
+       1161    17 -228.394620 -228.393764 8.560387e-04   0.002 1.13582e-02 4.14092e-05
+       1162    18 -228.396511 -228.393692 2.818390e-03   0.002 2.49070e-02 3.44040e-05
+       1163    18 -228.397790 -228.393581 4.208907e-03   0.002 3.40346e-02 2.36421e-05
+       1164    20 -228.398424 -228.393448 4.976105e-03   0.002 3.79810e-02 1.13349e-05
+       1165    25 -228.398302 -228.393313 4.988865e-03   0.002 3.65451e-02 6.35045e-06
+       1166    27 -228.397568 -228.393193 4.375121e-03   0.002 3.04568e-02 1.58894e-05
+       1167    23 -228.396324 -228.393103 3.221099e-03   0.002 2.09256e-02 2.41877e-05
+       1168    18 -228.394806 -228.393052 1.754092e-03   0.002 9.69531e-03 2.88389e-05
+       1169    18 -228.393262 -228.393044 2.181395e-04   0.002 4.01262e-03 2.93970e-05
+       1170    18 -228.391868 -228.393075 1.207565e-03   0.002 1.32553e-02 2.61329e-05
+       1171    18 -228.390762 -228.393139 2.376632e-03   0.002 2.08507e-02 1.98724e-05
+       1172    19 -228.390090 -228.393223 3.133429e-03   0.002 2.51406e-02 1.19560e-05
+       1173    24 -228.389884 -228.393316 3.431872e-03   0.002 2.57923e-02 5.44083e-06
+       1174    27 -228.390154 -228.393403 3.249507e-03   0.002 2.30074e-02 8.59031e-06
+       1175    24 -228.390810 -228.393475 2.665507e-03   0.002 1.75063e-02 1.46794e-05
+       1176    23 -228.391750 -228.393523 1.773144e-03   0.002 1.03293e-02 1.89237e-05
+       1177    18 -228.392768 -228.393542 7.742473e-04   0.002 3.43756e-03 2.05230e-05
+       1178    18 -228.393769 -228.393534 2.355409e-04   0.002 6.30841e-03 1.94469e-05
+       1179    18 -228.394616 -228.393501 1.115374e-03   0.002 1.20996e-02 1.60853e-05
+       1180    19 -228.395235 -228.393449 1.785792e-03   0.002 1.60310e-02 1.12407e-05
+       1181    24 -228.395547 -228.393389 2.158473e-03   0.002 1.75851e-02 6.39599e-06
+       1182    25 -228.395538 -228.393327 2.211292e-03   0.002 1.67104e-02 5.45099e-06
+       1183    25 -228.395242 -228.393273 1.969094e-03   0.002 1.37730e-02 8.92620e-06
+       1184    24 -228.394722 -228.393233 1.489119e-03   0.002 9.37924e-03 1.22672e-05
+       1185    19 -228.394072 -228.393210 8.619880e-04   0.002 4.52842e-03 1.41019e-05
+       1186    19 -228.393400 -228.393207 1.928291e-04   0.002 3.08597e-03 1.41491e-05
+       1187    19 -228.392779 -228.393222 4.428063e-04   0.002 6.79751e-03 1.25481e-05
+       1188    21 -228.392281 -228.393251 9.697789e-04   0.002 1.00141e-02 9.75398e-06
+       1189    20 -228.391984 -228.393289 1.305489e-03   0.002 1.17567e-02 6.60633e-06
+       1190    24 -228.391861 -228.393331 1.469617e-03   0.002 1.18665e-02 4.82868e-06
+       1191    25 -228.391961 -228.393370 1.408918e-03   0.002 1.04406e-02 6.00557e-06
+       1192    24 -228.392229 -228.393402 1.173211e-03   0.002 7.85415e-03 8.21765e-06
+       1193    22 -228.392604 -228.393423 8.187836e-04   0.002 4.63197e-03 9.83640e-06
+       1194    19 -228.393050 -228.393431 3.805617e-04   0.002 2.13165e-03 1.03718e-05
+       1195    20 -228.393466 -228.393427 3.961674e-05   0.002 3.59857e-03 9.78579e-06
+       1196    19 -228.393834 -228.393411 4.231344e-04   0.002 6.01157e-03 8.30388e-06
+       1197    20 -228.394092 -228.393388 7.045875e-04   0.002 7.63260e-03 6.40925e-06
+       1198    24 -228.394235 -228.393361 8.744590e-04   0.002 8.18031e-03 4.94178e-06
+       1199    24 -228.394233 -228.393333 8.999326e-04   0.002 7.63946e-03 4.88079e-06
+       1200    24 -228.394118 -228.393309 8.090753e-04   0.002 6.19454e-03 5.96237e-06
+       1201    23 -228.393908 -228.393292 6.161283e-04   0.002 4.16259e-03 7.11027e-06
+       1202    21 -228.393643 -228.393282 3.605632e-04   0.002 2.14776e-03 7.73269e-06
+       1203    19 -228.393366 -228.393282 8.430094e-05   0.002 2.00395e-03 7.65988e-06
+       1204    20 -228.393113 -228.393289 1.755454e-04   0.002 3.58248e-03 6.96608e-06
+       1205    19 -228.392916 -228.393302 3.861596e-04   0.002 4.92418e-03 5.91486e-06
+       1206    20 -228.392788 -228.393320 5.318937e-04   0.002 5.60110e-03 4.95090e-06
+       1207    24 -228.392753 -228.393338 5.855655e-04   0.002 5.52964e-03 4.58891e-06
+       1208    23 -228.392793 -228.393355 5.623462e-04   0.002 4.78367e-03 4.95391e-06
+       1209    21 -228.392909 -228.393369 4.602254e-04   0.002 3.53517e-03 5.61505e-06
+       1210    21 -228.393058 -228.393378 3.192680e-04   0.002 2.09879e-03 6.12206e-06
+       1211    20 -228.393235 -228.393381 1.456278e-04   0.002 1.26867e-03 6.25786e-06
+       1212    19 -228.393401 -228.393378 2.287129e-05   0.002 2.02794e-03 6.00022e-06
+       1213    20 -228.393548 -228.393371 1.775555e-04   0.002 3.05901e-03 5.46967e-06
+       1214    19 -228.393635 -228.393360 2.749968e-04   0.002 3.72249e-03 4.89603e-06
+       1215    22 -228.393690 -228.393348 3.424883e-04   0.002 3.89872e-03 4.54887e-06
+       1216    24 -228.393673 -228.393336 3.375709e-04   0.002 3.57914e-03 4.57249e-06
+       1217    19 -228.393623 -228.393325 2.974479e-04   0.002 2.86894e-03 4.85957e-06
+       1218    22 -228.393532 -228.393318 2.141212e-04   0.002 1.93689e-03 5.17521e-06
+       1219    19 -228.393424 -228.393315 1.092460e-04   0.002 1.14586e-03 5.33974e-06
+       1220    20 -228.393318 -228.393315 2.803395e-06   0.002 1.24239e-03 5.28711e-06
+       1221    20 -228.393216 -228.393319 1.023289e-04   0.002 1.92119e-03 5.05315e-06
+       1222    20 -228.393155 -228.393325 1.699094e-04   0.002 2.48548e-03 4.74786e-06
+       1223    20 -228.393112 -228.393333 2.211089e-04   0.002 2.75048e-03 4.51181e-06
+       1224    22 -228.393112 -228.393341 2.293941e-04   0.002 2.67576e-03 4.44410e-06
+       1225    19 -228.393137 -228.393349 2.113402e-04   0.002 2.30426e-03 4.53947e-06
+       1226    19 -228.393194 -228.393354 1.608193e-04   0.002 1.72696e-03 4.70364e-06
+       1227    19 -228.393257 -228.393358 1.008373e-04   0.002 1.12739e-03 4.82891e-06
+       1228    19 -228.393330 -228.393358 2.860179e-05   0.002 8.76211e-04 4.85130e-06
+       1229    19 -228.393392 -228.393357 3.561528e-05   0.002 1.18595e-03 4.76562e-06
+       1230    19 -228.393442 -228.393353 8.878499e-05   0.002 1.60629e-03 4.61583e-06
+       1231    19 -228.393471 -228.393348 1.226852e-04   0.002 1.87975e-03 4.47140e-06
+       1232    20 -228.393474 -228.393342 1.315377e-04   0.002 1.93541e-03 4.39275e-06
+       1233    19 -228.393462 -228.393337 1.246010e-04   0.002 1.77993e-03 4.39958e-06
+       1234    19 -228.393428 -228.393333 9.484925e-05   0.002 1.46044e-03 4.46384e-06
+       1235    19 -228.393384 -228.393330 5.449261e-05   0.002 1.07855e-03 4.53389e-06
+       1236    19 -228.393337 -228.393329 7.704807e-06   0.002 8.12681e-04 4.56614e-06
+       1237    19 -228.393294 -228.393329 3.533667e-05   0.002 8.59859e-04 4.54368e-06
+       1238    19 -228.393259 -228.393332 7.265376e-05   0.002 1.10290e-03 4.47843e-06
+       1239    19 -228.393239 -228.393335 9.554178e-05   0.002 1.32139e-03 4.40118e-06
+       1240    19 -228.393233 -228.393338 1.053197e-04   0.002 1.42148e-03 4.34496e-06
+       1241    19 -228.393244 -228.393342 9.808612e-05   0.002 1.38033e-03 4.32816e-06
+       1242    19 -228.393266 -228.393345 7.972246e-05   0.002 1.21862e-03 4.34670e-06
+       1243    19 -228.393297 -228.393348 5.105738e-05   0.002 9.87692e-04 4.37960e-06
+       1244    19 -228.393331 -228.393349 1.803561e-05   0.002 7.77665e-04 4.40278e-06
+       1245    19 -228.393361 -228.393349 1.199114e-05   0.002 7.03533e-04 4.40138e-06
+       1246    19 -228.393388 -228.393348 3.988786e-05   0.002 7.90310e-04 4.37490e-06
+       1247    19 -228.393403 -228.393346 5.710527e-05   0.002 9.28083e-04 4.33495e-06
+       1248    19 -228.393409 -228.393343 6.536744e-05   0.002 1.02340e-03 4.29801e-06
+       1249    19 -228.393402 -228.393341 6.166536e-05   0.002 1.03827e-03 4.27665e-06
+       1250    19 -228.393387 -228.393338 4.888175e-05   0.002 9.72523e-04 4.27391e-06
+       1251    19 -228.393365 -228.393336 2.880094e-05   0.002 8.51545e-04 4.28318e-06
+       1252    19 -228.393341 -228.393335 5.173042e-06   0.002 7.22996e-04 4.29324e-06
+       1253    19 -228.393315 -228.393335 1.968858e-05   0.002 6.47296e-04 4.29458e-06
+       1254    19 -228.393296 -228.393336 3.972314e-05   0.002 6.58135e-04 4.28377e-06
+       1255    19 -228.393282 -228.393337 5.483945e-05   0.002 7.24118e-04 4.26395e-06
+       1256    19 -228.393277 -228.393338 6.157419e-05   0.002 7.88301e-04 4.24228e-06
+       1257    19 -228.393280 -228.393340 6.014075e-05   0.002 8.14411e-04 4.22580e-06
+       1258    19 -228.393291 -228.393342 5.148959e-05   0.002 7.91780e-04 4.21797e-06
+       1259    19 -228.393307 -228.393343 3.646889e-05   0.002 7.29193e-04 4.21747e-06
+       1260    19 -228.393326 -228.393344 1.816736e-05   0.002 6.50634e-04 4.21965e-06
+       1261    19 -228.393346 -228.393345 1.014825e-06   0.002 5.88294e-04 4.21937e-06
+       1262    19 -228.393363 -228.393345 1.820931e-05   0.002 5.67466e-04 4.21359e-06
+       1263    19 -228.393375 -228.393344 3.126779e-05   0.002 5.86287e-04 4.20248e-06
+       1264    19 -228.393382 -228.393343 3.869419e-05   0.002 6.19151e-04 4.18879e-06
+       1265    19 -228.393381 -228.393342 3.969356e-05   0.002 6.40134e-04 4.17609e-06
+       1266    19 -228.393375 -228.393340 3.486870e-05   0.002 6.36259e-04 4.16690e-06
+       1267    19 -228.393364 -228.393339 2.442811e-05   0.002 6.07822e-04 4.16164e-06
+       1268    19 -228.393349 -228.393338 1.104454e-05   0.002 5.66225e-04 4.15872e-06
+       1269    19 -228.393334 -228.393338 3.610553e-06   0.002 5.28433e-04 4.15573e-06
+       1270    19 -228.393320 -228.393338 1.820579e-05   0.002 5.09419e-04 4.15075e-06
+       1271    19 -228.393309 -228.393338 2.905362e-05   0.002 5.12259e-04 4.14320e-06
+       1272    19 -228.393301 -228.393339 3.759104e-05   0.002 5.27231e-04 4.13392e-06
+       1273    19 -228.393300 -228.393340 3.998366e-05   0.002 5.39472e-04 4.12449e-06
+       1274    19 -228.393303 -228.393341 3.822704e-05   0.002 5.39226e-04 4.11636e-06
+       1275    19 -228.393310 -228.393342 3.170562e-05   0.002 5.23942e-04 4.11012e-06
+       1276    18 -228.393320 -228.393342 2.188212e-05   0.002 4.98560e-04 4.10537e-06
+       1277    18 -228.393332 -228.393343 1.061040e-05   0.002 4.71632e-04 4.10100e-06
+       1278    18 -228.393344 -228.393343 1.251642e-06   0.002 4.53297e-04 4.09595e-06
+       1279    18 -228.393354 -228.393343 1.140942e-05   0.002 4.47048e-04 4.08965e-06
+       1280    18 -228.393362 -228.393342 1.930707e-05   0.002 4.50530e-04 4.08225e-06
+       1281    18 -228.393366 -228.393342 2.359925e-05   0.002 4.55950e-04 4.07440e-06
+       1282    18 -228.393366 -228.393341 2.425898e-05   0.002 4.56516e-04 4.06688e-06
+       1283    18 -228.393362 -228.393341 2.125561e-05   0.002 4.48997e-04 4.06019e-06
+       1284    18 -228.393355 -228.393340 1.530988e-05   0.002 4.34689e-04 4.05434e-06
+       1285    18 -228.393347 -228.393340 7.335382e-06   0.002 4.18223e-04 4.04894e-06
+       1286    18 -228.393342 -228.393339 2.174226e-06   0.002 4.05086e-04 4.04345e-06
+       1287    18 -228.393327 -228.393339 1.237214e-05   0.002 3.98761e-04 4.03749e-06
+       1288    18 -228.393324 -228.393340 1.585856e-05   0.002 3.98491e-04 4.03096e-06
+       1289    18 -228.393317 -228.393340 2.292539e-05   0.002 4.00971e-04 4.02411e-06
+       1290    18 -228.393317 -228.393340 2.377295e-05   0.002 4.01271e-04 4.01730e-06
+       1291    18 -228.393317 -228.393341 2.388861e-05   0.002 3.96855e-04 4.01083e-06
+       1292    18 -228.393321 -228.393341 2.018105e-05   0.002 3.87368e-04 4.00481e-06
+       1293    18 -228.393326 -228.393342 1.523994e-05   0.002 3.75057e-04 3.99909e-06
+       1294    18 -228.393333 -228.393342 8.643141e-06   0.002 3.63313e-04 3.99343e-06
+       1295    18 -228.393345 -228.393342 3.241243e-06   0.002 3.55017e-04 3.98758e-06
+       1296    18 -228.393343 -228.393342 1.199759e-06   0.002 3.50894e-04 3.98143e-06
+       1297    18 -228.393353 -228.393342 1.103786e-05   0.002 3.49987e-04 3.97504e-06
+       1298    18 -228.393353 -228.393341 1.120468e-05   0.002 3.49187e-04 3.96857e-06
+       1299    18 -228.393355 -228.393341 1.404691e-05   0.002 3.46810e-04 3.96220e-06
+       1300    18 -228.393353 -228.393341 1.200294e-05   0.002 3.41317e-04 3.95604e-06
+       1301    18 -228.393350 -228.393341 9.909850e-06   0.002 3.33661e-04 3.95008e-06
+       1302    18 -228.393346 -228.393340 5.484040e-06   0.002 3.25508e-04 3.94422e-06
+       1303    18 -228.393341 -228.393340 1.013330e-06   0.002 3.18700e-04 3.93833e-06
+       1304    18 -228.393336 -228.393340 4.092608e-06   0.002 3.14327e-04 3.93233e-06
+       1305    18 -228.393332 -228.393340 8.061157e-06   0.002 3.12111e-04 3.92621e-06
+       1306    18 -228.393329 -228.393340 1.139581e-05   0.002 3.10823e-04 3.92002e-06
+       1307    18 -228.393328 -228.393341 1.311827e-05   0.002 3.08875e-04 3.91386e-06
+       1308    18 -228.393327 -228.393341 1.349199e-05   0.002 3.05264e-04 3.90778e-06
+       1309    18 -228.393329 -228.393341 1.234508e-05   0.002 2.99843e-04 3.90182e-06
+       1310    18 -228.393331 -228.393341 1.006063e-05   0.002 2.93384e-04 3.89593e-06
+       1311    18 -228.393334 -228.393341 6.922914e-06   0.002 2.87000e-04 3.89006e-06
+       1312    18 -228.393338 -228.393341 3.444947e-06   0.002 2.81722e-04 3.88414e-06
+       1313    18 -228.393342 -228.393341 2.837921e-07   0.002 2.77921e-04 3.87816e-06
+       1314    18 -228.393344 -228.393341 2.887760e-06   0.002 2.75266e-04 3.87212e-06
+       1315    18 -228.393346 -228.393341 5.225353e-06   0.002 2.72978e-04 3.86606e-06
+       1316    18 -228.393347 -228.393341 6.254932e-06   0.002 2.70268e-04 3.86004e-06
+       1317    18 -228.393347 -228.393341 6.417343e-06   0.002 2.66727e-04 3.85407e-06
+       1318    18 -228.393346 -228.393341 5.491547e-06   0.002 2.62447e-04 3.84816e-06
+       1319    18 -228.393345 -228.393341 3.855790e-06   0.002 2.57895e-04 3.84227e-06
+       1320    18 -228.393342 -228.393341 1.673888e-06   0.002 2.53658e-04 3.83639e-06
+       1321    18 -228.393340 -228.393341 5.476589e-07   0.002 2.50106e-04 3.83049e-06
+       1322    18 -228.393337 -228.393341 3.298392e-06   0.002 2.47280e-04 3.82456e-06
+       1323    18 -228.393336 -228.393341 4.826456e-06   0.002 2.44838e-04 3.81862e-06
+       1324    18 -228.393334 -228.393341 6.326395e-06   0.002 2.42371e-04 3.81269e-06
+       1325    18 -228.393334 -228.393341 6.809557e-06   0.002 2.39482e-04 3.80679e-06
+       1326    18 -228.393334 -228.393341 6.770855e-06   0.002 2.36148e-04 3.80091e-06
+       1327    18 -228.393335 -228.393341 5.966958e-06   0.002 2.32325e-04 3.79506e-06
+       1328    18 -228.393336 -228.393341 4.733287e-06   0.002 2.28461e-04 3.78921e-06
+       1329    18 -228.393338 -228.393341 3.155924e-06   0.002 2.24841e-04 3.78336e-06
+       1330    18 -228.393340 -228.393341 1.556784e-06   0.002 2.21631e-04 3.77750e-06
+       1331    18 -228.393342 -228.393341 8.697730e-07   0.002 2.18813e-04 3.77163e-06
+       1332    18 -228.393342 -228.393341 1.147487e-06   0.002 2.16210e-04 3.76576e-06
+       1333    18 -228.393344 -228.393341 2.523720e-06   0.002 2.13645e-04 3.75990e-06
+       1334    18 -228.393344 -228.393341 2.620734e-06   0.002 2.10938e-04 3.75405e-06
+       1335    16 -228.393344 -228.393341 2.702436e-06   0.002 2.07565e-04 3.74822e-06
+       1336    18 -228.393343 -228.393341 2.131917e-06   0.002 2.05283e-04 3.74238e-06
+       1337    16 -228.393342 -228.393341 1.339276e-06   0.002 2.01842e-04 3.73658e-06
+       1338    18 -228.393341 -228.393341 3.952307e-07   0.002 1.99688e-04 3.73077e-06
+       1339    16 -228.393340 -228.393341 5.941346e-07   0.002 1.96522e-04 3.72497e-06
+       1340    16 -228.393339 -228.393341 2.346233e-06   0.002 1.94323e-04 3.71916e-06
+       1341    16 -228.393338 -228.393341 2.777600e-06   0.002 1.91720e-04 3.71337e-06
+       1342    16 -228.393338 -228.393341 2.698709e-06   0.002 1.89613e-04 3.70758e-06
+       1343    16 -228.393338 -228.393341 3.194197e-06   0.002 1.86861e-04 3.70181e-06
+       1344    16 -228.393338 -228.393341 2.830109e-06   0.002 1.84376e-04 3.69604e-06
+       1345    16 -228.393338 -228.393341 2.706679e-06   0.002 1.81615e-04 3.69028e-06
+       1346    16 -228.393339 -228.393341 2.238435e-06   0.002 1.79225e-04 3.68452e-06
+       1347    17 -228.393341 -228.393341 4.201045e-07   0.002 1.76990e-04 3.67878e-06
+       1348    17 -228.393341 -228.393341 4.293921e-07   0.002 1.74663e-04 3.67303e-06
+       1349    16 -228.393336 -228.393341 5.404430e-06   0.002 1.71749e-04 3.66728e-06
+       1350    16 -228.393345 -228.393341 3.841132e-06   0.002 1.69718e-04 3.66155e-06
+       1351    16 -228.393340 -228.393341 1.044719e-06   0.002 1.67464e-04 3.65582e-06
+       1352    16 -228.393344 -228.393341 2.650343e-06   0.002 1.65309e-04 3.65010e-06
+       1353    16 -228.393334 -228.393341 7.099112e-06   0.002 1.63071e-04 3.64438e-06
+       1354    16 -228.393347 -228.393341 5.827510e-06   0.002 1.61241e-04 3.63868e-06
+       1355    16 -228.393339 -228.393341 2.367747e-06   0.002 1.58874e-04 3.63298e-06
+       1356    16 -228.393343 -228.393341 2.072519e-06   0.002 1.56924e-04 3.62728e-06
+       1357    16 -228.393339 -228.393341 1.626044e-06   0.002 1.54614e-04 3.62159e-06
+       1358    16 -228.393341 -228.393341 4.336619e-07   0.002 1.52838e-04 3.61591e-06
+       1359    16 -228.393340 -228.393341 1.461876e-06   0.002 1.50659e-04 3.61023e-06
+       1360    16 -228.393341 -228.393341 3.689050e-07   0.002 1.48707e-04 3.60457e-06
+       1361    16 -228.393340 -228.393341 1.607227e-06   0.002 1.46648e-04 3.59890e-06
+       1362    16 -228.393340 -228.393341 1.605189e-06   0.002 1.44756e-04 3.59325e-06
+       1363    17 -228.393341 -228.393341 1.378245e-07   0.002 1.43115e-04 3.58760e-06
+       1364    16 -228.393339 -228.393341 2.058683e-06   0.002 1.40484e-04 3.58195e-06
+       1365    16 -228.393338 -228.393341 3.125620e-06   0.002 1.39046e-04 3.57632e-06
+       1366    16 -228.393343 -228.393341 1.876251e-06   0.002 1.37076e-04 3.57068e-06
+       1367    15 -228.393339 -228.393341 1.852318e-06   0.002 1.35507e-04 3.56506e-06
+       1368    16 -228.393343 -228.393341 1.465148e-06   0.002 1.33422e-04 3.55944e-06
+       1369    15 -228.393340 -228.393341 1.270097e-06   0.002 1.31720e-04 3.55383e-06
+       1370    16 -228.393343 -228.393341 1.819881e-06   0.002 1.30157e-04 3.54822e-06
+       1371    15 -228.393340 -228.393341 6.856788e-07   0.002 1.28707e-04 3.54262e-06
+       1372    16 -228.393342 -228.393341 1.277321e-06   0.002 1.26696e-04 3.53702e-06
+       1373    15 -228.393339 -228.393341 1.760778e-06   0.002 1.25178e-04 3.53144e-06
+       1374    16 -228.393343 -228.393341 1.496620e-06   0.002 1.23576e-04 3.52585e-06
+       1375    15 -228.393340 -228.393341 1.204522e-06   0.002 1.21906e-04 3.52028e-06
+       1376    15 -228.393344 -228.393341 3.062490e-06   0.002 1.20320e-04 3.51471e-06
+       1377    15 -228.393338 -228.393341 2.783939e-06   0.002 1.18816e-04 3.50915e-06
+       1378    15 -228.393344 -228.393341 2.434472e-06   0.002 1.17180e-04 3.50359e-06
+       1379    15 -228.393339 -228.393341 2.565511e-06   0.002 1.15709e-04 3.49804e-06
+       1380    15 -228.393344 -228.393341 2.506391e-06   0.002 1.14101e-04 3.49250e-06
+       1381    15 -228.393339 -228.393341 2.589971e-06   0.002 1.12692e-04 3.48696e-06
+       1382    15 -228.393344 -228.393341 2.470376e-06   0.002 1.11189e-04 3.48143e-06
+       1383    15 -228.393339 -228.393341 2.392689e-06   0.002 1.09772e-04 3.47591e-06
+       1384    15 -228.393344 -228.393341 2.447586e-06   0.002 1.08311e-04 3.47039e-06
+       1385    15 -228.393339 -228.393341 1.967506e-06   0.002 1.07566e-04 3.46488e-06
+       1386    15 -228.393343 -228.393341 2.216817e-06   0.002 1.05790e-04 3.45938e-06
+       1387    15 -228.393339 -228.393341 1.760884e-06   0.002 1.04321e-04 3.45388e-06
+       1388    15 -228.393343 -228.393341 2.191189e-06   0.002 1.02966e-04 3.44838e-06
+       1389    15 -228.393340 -228.393341 1.564574e-06   0.002 1.01580e-04 3.44289e-06
+       1390    15 -228.393343 -228.393341 2.150131e-06   0.002 1.00387e-04 3.43741e-06
+       1391    15 -228.393340 -228.393341 1.398831e-06   0.002 9.90264e-05 3.43194e-06
+       1392    15 -228.393343 -228.393341 2.012604e-06   0.002 9.78892e-05 3.42647e-06
+       1393    15 -228.393340 -228.393341 1.253504e-06   0.002 9.64975e-05 3.42101e-06
+       1394    15 -228.393343 -228.393341 1.887123e-06   0.002 9.54546e-05 3.41556e-06
+       1395    15 -228.393340 -228.393341 1.142202e-06   0.002 9.40442e-05 3.41011e-06
+       1396    15 -228.393343 -228.393341 1.795531e-06   0.002 9.29968e-05 3.40467e-06
+       1397    15 -228.393340 -228.393341 1.090108e-06   0.002 9.16869e-05 3.39924e-06
+       1398    15 -228.393343 -228.393341 1.656261e-06   0.002 9.06931e-05 3.39381e-06
+       1399    15 -228.393340 -228.393341 1.014394e-06   0.002 8.94745e-05 3.38839e-06
+       1400    15 -228.393343 -228.393341 1.587243e-06   0.002 8.84502e-05 3.38297e-06
+       1401    15 -228.393340 -228.393341 9.844281e-07   0.002 8.71959e-05 3.37756e-06
+       1402    15 -228.393343 -228.393341 1.551785e-06   0.002 8.62283e-05 3.37216e-06
+       1403    15 -228.393340 -228.393341 9.012783e-07   0.002 8.50579e-05 3.36676e-06
+       1404    15 -228.393343 -228.393341 1.520847e-06   0.002 8.40904e-05 3.36137e-06
+       1405    15 -228.393340 -228.393341 8.118956e-07   0.002 8.28638e-05 3.35598e-06
+       1406    15 -228.393343 -228.393341 1.370769e-06   0.002 8.22489e-05 3.35060e-06
+       1407    15 -228.393341 -228.393341 4.962398e-07   0.002 8.09946e-05 3.34523e-06
+       1408    15 -228.393343 -228.393341 1.479922e-06   0.002 8.00030e-05 3.33987e-06
+       1409    15 -228.393341 -228.393341 4.906021e-07   0.002 7.88719e-05 3.33451e-06
+       1410    15 -228.393343 -228.393341 1.544407e-06   0.002 7.79792e-05 3.32915e-06
+       1411    14 -228.393341 -228.393341 9.759364e-08   0.002 7.63497e-05 3.32380e-06
+       1412    15 -228.393343 -228.393341 1.441458e-06   0.002 7.61170e-05 3.31846e-06
+       1413    15 -228.393341 -228.393341 4.885712e-07   0.002 7.46978e-05 3.31313e-06
+       1414    15 -228.393343 -228.393341 1.612256e-06   0.002 7.41814e-05 3.30780e-06
+       1415    15 -228.393341 -228.393341 4.740226e-07   0.002 7.28572e-05 3.30248e-06
+       1416    14 -228.393342 -228.393341 4.252163e-07   0.002 7.23435e-05 3.29716e-06
+       1417    15 -228.393341 -228.393341 9.752683e-09   0.002 7.12496e-05 3.29185e-06
+       1418    15 -228.393343 -228.393341 2.040040e-06   0.002 7.03608e-05 3.28655e-06
+       1419    15 -228.393341 -228.393341 7.270505e-07   0.002 6.93567e-05 3.28125e-06
+       1420    15 -228.393343 -228.393341 1.684661e-06   0.002 6.86255e-05 3.27596e-06
+       1421    15 -228.393341 -228.393341 5.359643e-07   0.002 6.76509e-05 3.27068e-06
+       1422    14 -228.393341 -228.393341 4.866133e-07   0.002 6.74004e-05 3.26540e-06
+       1423    14 -228.393351 -228.393341 9.352931e-06   0.002 6.68845e-05 3.26013e-06
+       1424    15 -228.393336 -228.393341 5.125589e-06   0.002 6.58627e-05 3.25487e-06
+       1425    15 -228.393345 -228.393341 4.101388e-06   0.002 6.45106e-05 3.24961e-06
+       1426    15 -228.393339 -228.393341 1.984478e-06   0.002 6.39624e-05 3.24435e-06
+       1427    15 -228.393344 -228.393341 2.565476e-06   0.002 6.29198e-05 3.23911e-06
+       1428    15 -228.393340 -228.393341 1.138258e-06   0.002 6.23796e-05 3.23387e-06
+       1429    14 -228.393340 -228.393341 1.185971e-06   0.002 6.13599e-05 3.22863e-06
+       1430    14 -228.393340 -228.393341 1.751026e-06   0.002 6.11588e-05 3.22341e-06
+       1431    14 -228.393336 -228.393341 5.250720e-06   0.002 6.03273e-05 3.21819e-06
+       1432    14 -228.393345 -228.393341 3.197430e-06   0.002 5.95408e-05 3.21298e-06
+       1433    15 -228.393341 -228.393341 5.033126e-07   0.002 5.86348e-05 3.20777e-06
+       1434    15 -228.393343 -228.393341 2.055987e-06   0.002 5.79957e-05 3.20257e-06
+       1435    15 -228.393341 -228.393341 3.390419e-08   0.002 5.72151e-05 3.19737e-06
+       1436    15 -228.393343 -228.393341 1.745251e-06   0.002 5.66968e-05 3.19218e-06
+       1437    15 -228.393341 -228.393341 3.168406e-08   0.002 5.58400e-05 3.18700e-06
+       1438    15 -228.393343 -228.393341 1.629115e-06   0.002 5.53777e-05 3.18182e-06
+       1439    14 -228.393343 -228.393341 2.011168e-06   0.002 5.45702e-05 3.17665e-06
+       1440    14 -228.393348 -228.393341 6.830410e-06   0.002 5.46728e-05 3.17149e-06
+       1441    15 -228.393338 -228.393341 3.352608e-06   0.002 5.35179e-05 3.16634e-06
+       1442    15 -228.393344 -228.393341 2.770333e-06   0.002 5.29528e-05 3.16118e-06
+       1443    15 -228.393340 -228.393341 1.100985e-06   0.002 5.21509e-05 3.15604e-06
+       1444    15 -228.393343 -228.393341 1.595213e-06   0.002 5.17303e-05 3.15090e-06
+       1445    15 -228.393341 -228.393341 3.888962e-07   0.002 5.09644e-05 3.14577e-06
+       1446    15 -228.393343 -228.393341 1.570395e-06   0.002 5.05490e-05 3.14064e-06
+       1447    15 -228.393341 -228.393341 1.392777e-07   0.002 4.98152e-05 3.13552e-06
+       1448    14 -228.393341 -228.393341 4.823765e-07   0.002 5.00930e-05 3.13041e-06
+       1449    13 -228.393344 -228.393341 2.195725e-06   0.002 4.89801e-05 3.12531e-06
+       1450    13 -228.393342 -228.393341 2.417186e-07   0.002 4.85151e-05 3.12021e-06
+       1451    14 -228.393335 -228.393341 6.816550e-06   0.002 4.85504e-05 3.11512e-06
+       1452    14 -228.393347 -228.393341 5.213727e-06   0.002 4.76219e-05 3.11004e-06
+       1453    15 -228.393340 -228.393341 1.253467e-06   0.002 4.68570e-05 3.10495e-06
+       1454    13 -228.393344 -228.393341 2.631738e-06   0.002 4.61636e-05 3.09988e-06
+       1455    15 -228.393342 -228.393341 8.366695e-08   0.002 4.59024e-05 3.09481e-06
+       1456    13 -228.393343 -228.393341 1.735209e-06   0.002 4.52366e-05 3.08975e-06
+       1457    15 -228.393342 -228.393341 2.470312e-07   0.002 4.49837e-05 3.08469e-06
+       1458    13 -228.393343 -228.393341 1.199812e-06   0.002 4.42761e-05 3.07965e-06
+       1459    15 -228.393342 -228.393341 2.366749e-07   0.002 4.41020e-05 3.07460e-06
+       1460    13 -228.393343 -228.393341 1.392668e-06   0.002 4.34487e-05 3.06957e-06
+       1461    15 -228.393341 -228.393341 2.670053e-09   0.002 4.32608e-05 3.06454e-06
+       1462    13 -228.393342 -228.393341 9.468352e-07   0.002 4.25912e-05 3.05952e-06
+       1463    15 -228.393342 -228.393341 1.792693e-07   0.002 4.24138e-05 3.05450e-06
+       1464    13 -228.393343 -228.393341 1.373980e-06   0.002 4.17591e-05 3.04949e-06
+       1465    15 -228.393342 -228.393341 7.318557e-08   0.002 4.15724e-05 3.04448e-06
+       1466    13 -228.393343 -228.393341 1.237739e-06   0.002 4.09265e-05 3.03949e-06
+       1467    15 -228.393342 -228.393341 3.249996e-07   0.002 4.07636e-05 3.03449e-06
+       1468    13 -228.393343 -228.393341 1.353697e-06   0.002 4.01507e-05 3.02951e-06
+       1469    15 -228.393342 -228.393341 4.291907e-07   0.002 4.00121e-05 3.02453e-06
+       1470    13 -228.393343 -228.393341 1.468881e-06   0.002 3.94273e-05 3.01956e-06
+       1471    15 -228.393342 -228.393341 4.722303e-07   0.002 3.92911e-05 3.01459e-06
+       1472    13 -228.393343 -228.393341 1.506942e-06   0.002 3.87324e-05 3.00963e-06
+       1473    15 -228.393342 -228.393342 4.927993e-07   0.002 3.85998e-05 3.00468e-06
+       1474    13 -228.393343 -228.393342 1.508740e-06   0.002 3.80517e-05 2.99974e-06
+       1475    15 -228.393342 -228.393342 4.668069e-07   0.002 3.79037e-05 2.99479e-06
+       1476    13 -228.393343 -228.393342 1.360229e-06   0.002 3.73900e-05 2.98986e-06
+       1477    15 -228.393342 -228.393342 4.570222e-07   0.002 3.72700e-05 2.98493e-06
+       1478    13 -228.393343 -228.393342 1.358310e-06   0.002 3.67680e-05 2.98001e-06
+       1479    15 -228.393342 -228.393342 3.780356e-07   0.002 3.66627e-05 2.97510e-06
+       1480    13 -228.393343 -228.393342 1.094242e-06   0.002 3.61589e-05 2.97019e-06
+       1481    13 -228.393340 -228.393342 1.129519e-06   0.002 3.58085e-05 2.96529e-06
+       1482    13 -228.393346 -228.393342 4.752934e-06   0.002 3.56118e-05 2.96040e-06
+       1483    15 -228.393340 -228.393342 1.580367e-06   0.002 3.56265e-05 2.95551e-06
+       1484    13 -228.393344 -228.393342 2.340460e-06   0.002 3.48708e-05 2.95063e-06
+       1485    13 -228.393341 -228.393342 9.080528e-07   0.002 3.46496e-05 2.94576e-06
+       1486    13 -228.393345 -228.393342 3.679757e-06   0.002 3.44833e-05 2.94090e-06
+       1487    15 -228.393341 -228.393342 7.729426e-07   0.002 3.45379e-05 2.93604e-06
+       1488    12 -228.393345 -228.393342 3.859182e-06   0.002 3.41018e-05 2.93120e-06
+       1489    13 -228.393341 -228.393342 5.781201e-07   0.002 3.43076e-05 2.92637e-06
+       1490    13 -228.393344 -228.393342 2.305019e-06   0.002 3.35263e-05 2.92153e-06
+       1491    15 -228.393342 -228.393342 1.198016e-07   0.002 3.39825e-05 2.91670e-06
+       1492    13 -228.393343 -228.393342 1.511548e-06   0.002 3.30956e-05 2.91187e-06
+       1493    13 -228.393342 -228.393342 2.256602e-07   0.002 3.33258e-05 2.90705e-06
+       1494    15 -228.393343 -228.393342 1.836940e-06   0.002 3.29554e-05 2.90223e-06
+       1495    13 -228.393342 -228.393342 5.189824e-07   0.002 3.27586e-05 2.89742e-06
+       1496    13 -228.393345 -228.393342 3.410737e-06   0.002 3.24377e-05 2.89263e-06
+       1497    15 -228.393341 -228.393342 5.189719e-07   0.002 3.27139e-05 2.88783e-06
+       1498    13 -228.393343 -228.393342 1.861226e-06   0.002 3.20919e-05 2.88303e-06
+       1499    13 -228.393341 -228.393342 4.360677e-07   0.002 3.20648e-05 2.87825e-06
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization converged in   2 iterations 
+            Total energy change: -4.547474e-13
+            Final gradient norm: 1.831719e-07
+
+       1500    13 -228.393346 -228.393341 4.500821e-06   0.026 3.21434e-05 2.87350e-06
+       1501    19 -228.393341 -228.393342 9.912289e-07   0.026 2.85479e-05 2.90324e-06
+       1502    19 -228.393344 -228.393342 2.056360e-06   0.026 2.19873e-05 2.90244e-06
+       1503    18 -228.393342 -228.393342 1.781455e-08   0.026 1.80286e-05 2.90100e-06
+       1504    18 -228.393343 -228.393342 1.005571e-06   0.026 1.60253e-05 2.89486e-06
+       1505    17 -228.393342 -228.393342 2.597247e-07   0.026 1.41459e-05 2.88788e-06
+       1506    17 -228.393343 -228.393342 6.264576e-07   0.026 1.19412e-05 2.88238e-06
+       1507    16 -228.393343 -228.393342 5.931403e-07   0.026 9.74403e-06 2.87855e-06
+
+        ==> Orbital Optimization <==
+
+            Orbital Optimization converged in   2 iterations 
+            Total energy change: -9.663381e-13
+            Final gradient norm: 2.290663e-07
+
+
+      v2RDM iterations converged!
+
+      v2RDM total spin [S(S+1)]:            -0.000001
+    * v2RDM total energy:           -228.393342811795
+
+
+ # Natural Orbital Occupation Numbers (alpha) #
+ Irrep: 1
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  1.0000000
+      6:  1.0000000
+      7:  0.0000000
+      8:  0.0000000
+      9:  0.0000000
+
+ Irrep: 2
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  0.0000000
+      5:  0.0000000
+      6:  0.0000000
+
+ Irrep: 3
+      1:  0.4999999
+
+ Irrep: 4
+      1:  0.5000006
+      2:  0.5000002
+
+ Irrep: 5
+      1:  0.4999995
+
+ Irrep: 6
+      1:  0.5000002
+      2:  0.4999996
+
+ Irrep: 7
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  1.0000000
+      6:  0.0000000
+      7:  0.0000000
+      8:  0.0000000
+      9:  0.0000000
+
+ Irrep: 8
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  0.0000000
+      6:  0.0000000
+
+
+ # Natural Orbital Occupation Numbers (beta) #
+ Irrep: 1
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  1.0000000
+      6:  1.0000000
+      7:  0.0000000
+      8:  0.0000000
+      9:  0.0000000
+
+ Irrep: 2
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  0.0000000
+      5:  0.0000000
+      6:  0.0000000
+
+ Irrep: 3
+      1:  0.4999999
+
+ Irrep: 4
+      1:  0.5000006
+      2:  0.5000002
+
+ Irrep: 5
+      1:  0.4999995
+
+ Irrep: 6
+      1:  0.5000002
+      2:  0.4999996
+
+ Irrep: 7
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  1.0000000
+      6:  0.0000000
+      7:  0.0000000
+      8:  0.0000000
+      9:  0.0000000
+
+ Irrep: 8
+      1:  1.0000000
+      2:  1.0000000
+      3:  1.0000000
+      4:  1.0000000
+      5:  0.0000000
+      6:  0.0000000
+
+
+  ==> Iteration count <==
+
+      Microiterations:                   24802
+      Macroiterations:                    1508
+      Orbital optimization steps:            4
+
+  ==> Wall time <==
+
+      Microiterations:                    3.79 s
+      Macroiterations:                    1.02 s
+      Orbital optimization:               0.41 s
+      Total:                              5.66 s
+
+
+*** tstop() called on ed10 at Thu Jun 14 17:09:27 2018
+Module time:
+	user time   =       5.27 seconds =       0.09 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =      61.40 seconds =       1.02 minutes
+	system time =       0.47 seconds =       0.01 minutes
+	total time  =         64 seconds =       1.07 minutes
+	v2RDM-CASSCF total energy.........................................PASSED
+
+    Psi4 stopped on: Thursday, 14 June 2018 05:09PM
+    Psi4 wall time for execution: 0:01:04.81
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/v2rdm_casscf.cc
+++ b/v2rdm_casscf.cc
@@ -51,7 +51,9 @@ int read_options(std::string name, Options& options)
         options.add_str("DERTYPE", "NONE", "NONE FIRST");
         /*- Do optimize orbitals? -*/
         options.add_bool("OPTIMIZE_ORBITALS",true);
-        /*- Do semicanonicalize orbitals? -*/
+        /*- Rotate guess orbitals -*/
+        options.add("MCSCF_ROTATE", new ArrayType());
+		/*- Do semicanonicalize orbitals? -*/
         options.add_bool("SEMICANONICALIZE_ORBITALS",false);
         /*- Type of guess -*/
         options.add_str("TPDM_GUESS","RANDOM", "RANDOM HF");
@@ -140,6 +142,11 @@ int read_options(std::string name, Options& options)
         (if set), or else by the name of the output file plus the name of
         the current molecule. -*/
         options.add_bool("MOLDEN_WRITE", false);
+        /*- Do write a MOLDEN file for guess orbitals?  If so, the filename will
+        end in .guess.molden, and the prefix is determined by 
+        |globals__writer_file_label| (if set), or else by the name of the output
+        file plus the name of the current molecule. -*/
+        options.add_bool("GUESS_ORBITALS_WRITE", false);
         /*- Do write a ORBOPT output file?  If so, the filename will end in
         .molden, and the prefix is determined by |globals__writer_file_label|
         (if set), or else by the name of the output file plus the name of

--- a/v2rdm_solver.cc
+++ b/v2rdm_solver.cc
@@ -1616,6 +1616,34 @@ double v2RDMSolver::compute_energy() {
 
     double start_total_time = omp_get_wtime();
 
+
+    // print guess orbitals in molden format
+    if ( options_.get_bool("GUESS_ORBITALS_WRITE") ) {
+
+        std::shared_ptr<MoldenWriter> molden(new MoldenWriter(reference_wavefunction_));
+        std::shared_ptr<Vector> zero (new Vector("",nirrep_,nmopi_));
+        zero->zero();
+        std::string filename = get_writer_file_prefix(reference_wavefunction_->molecule()->name()) + ".guess.molden";
+
+        Ca_ = SharedMatrix(reference_wavefunction_->Ca());
+        Cb_ = SharedMatrix(reference_wavefunction_->Cb());
+
+        SharedVector occupation_a= SharedVector(new Vector(nirrep_, nmopi_));
+		SharedVector occupation_b= SharedVector(new Vector(nirrep_, nmopi_));
+
+		for (int h = 0; h < nirrep_; h++) {
+			for (int i = 0; i < nalphapi_[h]; i++) {
+				occupation_a->set(h, i, 1.0);
+			}
+			for (int i = 0; i < nbetapi_[h]; i++) {
+				occupation_b->set(h, i, 1.0);
+			}
+		}
+
+        molden->write(filename, Ca_, Cb_, zero, zero, occupation_a, occupation_b, true);
+
+    }
+
     // hartree-fock guess
     Guess();
 


### PR DESCRIPTION
…CF calculations

-Keyword: MCSCF_ROTATE [[irrep,orb1,orb2,theta],[irrep,orb1,orb2,theta],...]
          ROTATE ORB1 and ORB2 WITHIN THE IRREP
          Setting theta to be 90 switchs the orbitals, setting it to be 0 does nothing.
          Note all indicies start from 0.
-Keyword: GUESS_ORBITALS_WRITE false
          WRITE OUT THE GUESS ORBITALS AFTER ROTATIONS (IF APPLY)